### PR TITLE
docs: add EU Data Protection & PETs jurisdiction card

### DIFF
--- a/jurisdictions/eu-data-protection.md
+++ b/jurisdictions/eu-data-protection.md
@@ -1,0 +1,40 @@
+---
+title: "EU Data Protection & Privacy-Enhancing Technologies"
+status: draft
+region: EU
+scope:
+  entities: [CASPs, custodians, exchanges, wallet providers]
+  activities: [custody, KYC/AML, data processing, cross-border transfers]
+key-regulations: [GDPR (EU 2016/679), DORA (EU 2022/2554), MiCA (EU 2023/1114)]
+---
+
+## At a Glance
+
+The EU's General Data Protection Regulation (GDPR) and Digital Operational Resilience Act (DORA) establish data protection obligations that apply to crypto entities alongside MiCA requirements. While MiCA regulates crypto-asset service providers, GDPR governs personal data processing, and DORA addresses ICT resilience and incident reporting. This card highlights the intersection of these frameworks and emerging privacy-enhancing technology discussions.
+
+## Core Compliance Expectations
+
+- **Data minimisation**: Under GDPR Articles 5–6, entities must collect only what is necessary for defined purposes and document lawful basis for processing.
+- **Cross-border data transfers**: Use adequacy decisions or Standard Contractual Clauses (SCCs) for transfers outside the EU.
+- **Incident reporting**: DORA Articles 17–19 require reporting of major ICT incidents to competent authorities.
+- **Privacy-enhancing technologies**: Zero-knowledge proofs and secure computation techniques are increasingly discussed as potential tools for balancing data protection with regulatory obligations.
+
+## Key Risks to Watch
+
+- **Regulatory ambiguity on anonymisation vs pseudonymisation**: Classification affects whether GDPR applies (see EDPB Guidelines 01/2025).
+- **Divergent national interpretations**: Member State authorities may differ on whether privacy-enhancing approaches satisfy AML record-keeping requirements.
+- **Right to erasure vs blockchain immutability**: GDPR Article 17 creates challenges for immutable ledger architectures (see EDPB Guidelines 02/2025).
+
+## Enterprise Opportunities
+
+- **First-mover advantage in privacy-preserving compliance**: Institutions that pilot privacy-enhancing technologies (selective disclosure, zero-knowledge proofs) for KYC/AML may differentiate themselves as regulatory frameworks evolve.
+- **MiCA passporting with GDPR readiness**: CASPs demonstrating robust cross-border data governance can leverage MiCA's single-market passport more effectively across Member States.
+- **Institutional trust through transparency**: Public documentation of GDPR-DORA compliance frameworks signals operational maturity to institutional counterparties and NCAs.
+
+## See Also
+
+- [Regulation (EU) 2016/679 – General Data Protection Regulation (GDPR) – EUR-Lex](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+- [Regulation (EU) 2022/2554 – Digital Operational Resilience Act (DORA) – EUR-Lex](https://eur-lex.europa.eu/eli/reg/2022/2554/oj)
+- [EDPB Guidelines 02/2025 – Processing of Personal Data Through Blockchain](https://www.edpb.europa.eu/our-work-tools/general-guidance/guidelines-recommendations-best-practices_en)
+- [EDPB Guidelines 01/2025 – Pseudonymisation](https://www.edpb.europa.eu/our-work-tools/general-guidance/guidelines-recommendations-best-practices_en)
+- [EU MiCA Jurisdiction Card](./eu-MiCA.md)


### PR DESCRIPTION
I created a new jurisdiction card covering GDPR and DORA obligations for crypto entities operating in the EU, with a focus on data protection compliance and privacy-enhancing technologies.

This card addresses the intersection of three regulatory frameworks:
- GDPR (EU 2016/679) for personal data processing obligations
- DORA (EU 2022/2554) for ICT resilience and incident reporting
- MiCA (EU 2023/1114) for crypto-asset service provider requirements

It highlights key compliance expectations, including data minimisation, cross-border transfers, and emerging PET discussions. Identifies regulatory risks such as anonymisation vs pseudonymisation ambiguity and divergent Member State interpretations.

References current EDPB Guidelines 02/2025 (Blockchain) and 01/2025 (Pseudonymisation) adopted in 2025.

This fills a gap in IPTF institutional privacy mapping by providing high level regulatory landscape overview for institutions navigating EU data protection requirements.