### PR TITLE
feat(patterns): add threshold encrypted mempool pattern

### DIFF
--- a/patterns/pattern-threshold-encrypted-mempool.md
+++ b/patterns/pattern-threshold-encrypted-mempool.md
@@ -19,6 +19,8 @@ dependencies: [Threshold cryptography, Distributed key generation, Block builder
 
 ## Intent
 
+> **Sub-pattern of [Private Transaction Broadcasting](pattern-private-transaction-broadcasting.md)** — This pattern provides detailed coverage of threshold encryption specifically. See the parent pattern for alternative approaches (private relays, TEE-based builders).
+
 Prevent MEV extraction by encrypting transaction content before mempool submission, with decryption occurring only after block ordering is committed. A distributed committee holds threshold key shares; no single party can decrypt prematurely. This provides cryptographic (not trust-based) protection against front-running while maintaining censorship resistance.
 
 ## Ingredients


### PR DESCRIPTION
## Summary

- Add `pattern-threshold-encrypted-mempool.md` documenting k-of-n threshold encryption for MEV protection
- Cover committee models, trust assumptions, and failure modes
- Include Shutter as primary implementation example

## Details

| Field | Value |
|-------|-------|
| Status | draft |
| Maturity | pilot |
| Layer | L1 |
| Size | 142 lines |

**Key sections:**
- Committee Assumptions table (honest threshold, liveness, collusion)
- Protocol steps (encryption + decryption phases)
- Failure Modes table (5 failure scenarios)
- Comparison with alternatives (relay, timelock, TEE)

## Test plan

- [x] `node scripts/validate-patterns.js` passes
- [x] All required sections present
- [x] Links to related patterns and Shutter vendor

Implements PR-005 from PRD Sprint 1.