### PR TITLE
feat(rfps): add preliminary RFP proposals for PSE research and grants

### DIFF
--- a/rfps/README.md
+++ b/rfps/README.md
@@ -41,7 +41,6 @@ Tightly-scoped tooling and integration work suitable for external teams:
 
 | RFP | Category | Why Now |
 |-----|----------|---------|
-| [Private Reads / RPC Privacy](rfp-private-reads.md) | PSE Research | Metadata leakage before tx submission is a silent killer |
 | [Custody Controls SDK](rfp-custody-sdk.md) | Grant | "Day 2" operational blocker for institutions |
 | [Privacy Pools Integration](rfp-privacy-pools.md) | Grant | Compliance-friendly privacy narrative |
 
@@ -49,6 +48,7 @@ Tightly-scoped tooling and integration work suitable for external teams:
 
 | RFP | Category | Notes |
 |-----|----------|-------|
+| [Private Reads / RPC Privacy](rfp-private-reads.md) | PSE Research | Less critical for large institutions running own nodes |
 | [zk-SPV for Private DvP](rfp-zk-spv-dvp.md) | PSE Research | Cross-chain settlement with privacy + atomicity |
 | [Compliance Primitives Toolkit](rfp-compliance-primitives.md) | Grant | ZK credentials, Travel Rule plumbing |
 
@@ -56,8 +56,8 @@ Tightly-scoped tooling and integration work suitable for external teams:
 
 | Category | Count | Focus |
 |----------|-------|-------|
-| PSE Research | 3 | Protocol design, threat models, cryptographic research |
-| Grants | 4 | Tooling, integrations, benchmarks, documentation |
+| PSE Research | 3 | Trust analysis, RPC privacy, cross-chain DvP |
+| Grants | 4 | Benchmarks, custody SDK, Privacy Pools, compliance |
 
 ## How to Propose New RFPs
 

--- a/rfps/_template.md
+++ b/rfps/_template.md
@@ -3,7 +3,6 @@ title: "RFP: <Short Name>"
 status: draft
 category: pse-research | grant
 tier: 0 | 1 | 2
-effort: X-Y weeks
 ---
 
 # RFP: <Title>

--- a/rfps/rfp-benchmark-dashboard.md
+++ b/rfps/rfp-benchmark-dashboard.md
@@ -3,7 +3,6 @@ title: "RFP: Living Benchmark Dashboard"
 status: draft
 category: grant
 tier: 0
-effort: 8-10 weeks
 ---
 
 # RFP: Living Benchmark Dashboard

--- a/rfps/rfp-compliance-primitives.md
+++ b/rfps/rfp-compliance-primitives.md
@@ -3,7 +3,6 @@ title: "RFP: Compliance Primitives Toolkit"
 status: draft
 category: grant
 tier: 2
-effort: 8-10 weeks
 ---
 
 # RFP: Compliance Primitives Toolkit

--- a/rfps/rfp-custody-sdk.md
+++ b/rfps/rfp-custody-sdk.md
@@ -3,7 +3,6 @@ title: "RFP: Custody Controls Reference SDK"
 status: draft
 category: grant
 tier: 1
-effort: 8-10 weeks
 ---
 
 # RFP: Custody Controls Reference SDK

--- a/rfps/rfp-privacy-pools.md
+++ b/rfps/rfp-privacy-pools.md
@@ -3,7 +3,6 @@ title: "RFP: Privacy Pools Institutional Integration"
 status: draft
 category: grant
 tier: 1
-effort: 6-8 weeks
 ---
 
 # RFP: Privacy Pools Institutional Integration

--- a/rfps/rfp-private-reads.md
+++ b/rfps/rfp-private-reads.md
@@ -2,8 +2,7 @@
 title: "RFP: Private Reads / RPC Privacy"
 status: draft
 category: pse-research
-tier: 1
-effort: 6-8 weeks
+tier: 2
 ---
 
 # RFP: Private Reads / RPC Privacy
@@ -11,6 +10,8 @@ effort: 6-8 weeks
 ## Problem
 
 Most institutional privacy discussions focus on transaction privacy (hiding sender, receiver, amount). But institutions leak sensitive information *before* ever posting a transaction: RPC queries reveal portfolio positions, trading intent, counterparty relationships, and risk exposures. An observer monitoring RPC traffic can infer strategy without seeing any on-chain activity.
+
+**Note:** This is less of a pain point for large institutions that run their own nodes. For them, [private transaction broadcasting](../patterns/pattern-private-transaction-broadcasting.md) is a more significant need. This RFP targets smaller institutions or those using third-party RPC providers.
 
 ## Why It Matters
 

--- a/rfps/rfp-trust-assurance.md
+++ b/rfps/rfp-trust-assurance.md
@@ -3,7 +3,6 @@ title: "RFP: Trust Assurance Framework"
 status: draft
 category: pse-research
 tier: 0
-effort: 4-6 weeks
 ---
 
 # RFP: Trust Assurance Framework

--- a/rfps/rfp-zk-spv-dvp.md
+++ b/rfps/rfp-zk-spv-dvp.md
@@ -3,7 +3,6 @@ title: "RFP: zk-SPV for Private Cross-Chain DvP"
 status: draft
 category: pse-research
 tier: 2
-effort: 8-12 weeks (recommend phased)
 ---
 
 # RFP: zk-SPV for Private Cross-Chain DvP
@@ -17,13 +16,13 @@ Delivery-versus-Payment (DvP) is fundamental to institutional settlement: asset 
 - DvP is non-negotiable for institutional settlement (principal risk = regulatory concern)
 - Cross-chain is reality: institutions operate across multiple networks
 - Privacy + atomicity is the "holy grail" for institutional adoption
-- Informs ERC-7573 extensions and future settlement patterns
+- Informs ERC-7573 (draft) extensions and future settlement patterns
 
 ## Scope
 
 ### In-Scope
 
-**Phase A: Design & Specification (6-8 weeks)**
+**Phase A: Design & Specification**
 - Design space analysis for private cross-chain DvP:
   - zk-SPV (succinct cross-chain verification)
   - ZK-HTLC variants
@@ -33,9 +32,9 @@ Delivery-versus-Payment (DvP) is fundamental to institutional settlement: asset 
 - Threat model for each approach
 - Protocol specification for most promising candidate
 
-**Phase B: Reference Implementation (6-8 weeks, optional)**
+**Phase B: Reference Implementation (optional)**
 - Prototype implementation
-- Integration with ERC-7573 DvP standard
+- Integration with ERC-7573 (draft) DvP standard
 - Cross-chain proof-of-concept (e.g., Ethereum ↔ L2)
 
 ### Out-of-Scope
@@ -54,7 +53,7 @@ Delivery-versus-Payment (DvP) is fundamental to institutional settlement: asset 
 
 **Phase B (if funded):**
 - [ ] Reference implementation (Solidity + off-chain components)
-- [ ] Integration guide for ERC-7573
+- [ ] Integration guide for ERC-7573 (draft)
 - [ ] Cross-chain PoC demo
 
 ## Dependencies
@@ -65,12 +64,12 @@ Delivery-versus-Payment (DvP) is fundamental to institutional settlement: asset 
 
 **Enables:**
 - Private institutional settlement infrastructure
-- Extensions to ERC-7573
+- Extensions to ERC-7573 (draft)
 - Foundation for multi-leg settlement
 
 ## See Also
 
-- [Pattern: DvP Settlement (ERC-7573)](../patterns/pattern-dvp-erc7573.md)
+- [Pattern: DvP Settlement (ERC-7573, draft)](../patterns/pattern-dvp-erc7573.md)
 - [Pattern: ZK Light Client Bridge](../patterns/pattern-zk-light-client-bridge.md)
 - [Use Case: Private Bonds](../use-cases/private-bonds.md)
-- [ERC-7573 Specification](https://eips.ethereum.org/EIPS/eip-7573)
+- [ERC-7573 Specification (draft)](https://eips.ethereum.org/EIPS/eip-7573)


### PR DESCRIPTION
## Summary

- Adds `rfps/` folder with preliminary research proposals for PSE researchers and external grants
- 7 RFP sketches organized by priority tier (Tier 0/1/2)
- Non-critical-path work that strengthens the broader privacy ecosystem without blocking core PoC work

## RFPs Included

**Tier 0 (Do First):**
- Trust Assurance Framework — standardized threat model cards per privacy system
- Living Benchmark Dashboard — automated CI benchmarks for privacy L2s

**Tier 1 (High Demand):**
- Private Reads / RPC Privacy — metadata leakage research
- Custody Controls SDK — view keys, backup, policy approvals
- Privacy Pools Integration — compliance-friendly privacy

**Tier 2 (Strategic):**
- zk-SPV for Private DvP — cross-chain settlement with privacy + atomicity
- Compliance Primitives Toolkit — ZK credentials, Travel Rule plumbing

## Test plan

- [ ] Verify all markdown files render correctly
- [ ] Check cross-links to patterns/use-cases resolve
- [ ] Review for any accidentally leaked confidential info
- [ ] Confirm no specific institution names in requirements