### PR TITLE
feat(ci): add changelog validation and update instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,6 +63,20 @@ Each directory has `_template.md` and `README.md`. Key structures:
 - `refactor:` - Reorganizing without changing meaning
 - `chore:` - Maintenance tasks
 
+## Changelog Requirements
+
+**Always update CHANGELOG.md** when adding new content or making significant changes:
+
+1. Add entry to `[Unreleased]` section
+2. Use semantic prefix: `feat(pattern):`, `feat(vendor):`, `fix:`, `docs:`, etc.
+3. Link to the file: `[Name](path/to/file.md)`
+4. Link to PR: `([#123](https://github.com/ethereum/iptf-map/pull/123))`
+
+Example:
+```markdown
+- feat(pattern): [New pattern name](patterns/pattern-slug.md) ([#123](https://github.com/ethereum/iptf-map/pull/123))
+```
+
 ## Content Organization
 
 1. **Patterns** = Reusable building blocks (single architectural solution)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,48 @@ jobs:
               fi
             fi
           done
+
+  validate-changelog:
+    runs-on: ubuntu-latest
+    name: Validate Changelog
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changelog update
+        run: |
+          # Get list of changed files in PR
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          # Check if content directories were modified
+          CONTENT_CHANGED=false
+          for pattern in "patterns/" "vendors/" "approaches/" "use-cases/" "jurisdictions/" "domains/"; do
+            if echo "$CHANGED_FILES" | grep -q "^$pattern"; then
+              CONTENT_CHANGED=true
+              break
+            fi
+          done
+
+          # Check if CHANGELOG.md was updated
+          CHANGELOG_UPDATED=false
+          if echo "$CHANGED_FILES" | grep -q "^CHANGELOG.md"; then
+            CHANGELOG_UPDATED=true
+          fi
+
+          # Warn if content changed but changelog wasn't updated
+          if [ "$CONTENT_CHANGED" = true ] && [ "$CHANGELOG_UPDATED" = false ]; then
+            echo "::warning::Content files were modified but CHANGELOG.md was not updated."
+            echo "::warning::Please add an entry to the [Unreleased] section in CHANGELOG.md"
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **Changelog Reminder**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Content files were modified. Please update CHANGELOG.md:" >> $GITHUB_STEP_SUMMARY
+            echo "1. Add entry to \`[Unreleased]\` section" >> $GITHUB_STEP_SUMMARY
+            echo "2. Use format: \`- feat(type): [Name](path) ([#PR](url))\`" >> $GITHUB_STEP_SUMMARY
+          elif [ "$CHANGELOG_UPDATED" = true ]; then
+            echo "✅ CHANGELOG.md was updated" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ All notable changes to the IPTF Map are documented here.
 - feat(pattern): [Threshold encrypted mempool](patterns/pattern-threshold-encrypted-mempool.md) ([#45](https://github.com/ethereum/iptf-map/pull/45))
 - feat(vendor): [Fhenix](vendors/fhenix.md) - FHE privacy ([#32](https://github.com/ethereum/iptf-map/pull/32))
 - feat(ci): Pattern validation workflow ([#40](https://github.com/ethereum/iptf-map/pull/40))
+- feat(approach): [Private bond PoC](approaches/approach-private-bonds.md) updates ([#47](https://github.com/ethereum/iptf-map/pull/47))
 - docs: [Q1 2026 PRD](PRD-IPTF-PUBLIC-Q1-2026.md) with sprint planning ([#39](https://github.com/ethereum/iptf-map/pull/39))
+- docs: [CHANGELOG.md](CHANGELOG.md) and weekly summary script ([#49](https://github.com/ethereum/iptf-map/pull/49))
+- docs(prd): Sprint 6 for client-side proving and compliance
+- docs(prd): Source citations for accuracy verification findings
+- docs(prd): Sprint 1 completion and accuracy findings
+- docs(prd): GitHub issue traceability and missing deliverables
+- chore: Claude Code project configuration ([#36](https://github.com/ethereum/iptf-map/pull/36))
 
 ### Fixed
 - fix(pattern): Required frontmatter fields across all patterns ([#42](https://github.com/ethereum/iptf-map/pull/42))


### PR DESCRIPTION
## Summary
- Add changelog requirements to CLAUDE.md for AI assistants
- Add missing Jan 2026 commits to CHANGELOG
- Add CI job to warn when content changes without changelog update

## Changes

### CLAUDE.md
Added "Changelog Requirements" section with format instructions.

### CHANGELOG.md
Added missing entries since Jan 1:
- Private bond PoC updates (#47)
- Changelog and weekly summary script (#49)
- PRD updates (Sprint 6, Sprint 1 completion, citations)
- Claude Code configuration (#36)

### CI Workflow
New `validate-changelog` job that:
- Runs on PRs only
- Checks if content directories (patterns/, vendors/, etc.) were modified
- Warns if CHANGELOG.md wasn't updated
- Shows reminder in PR summary

## Test plan
- [ ] Verify CI runs on this PR
- [ ] Check CLAUDE.md renders correctly
- [ ] Confirm changelog entries are accurate