### PR TITLE
feat(docs): add weekly-updates directory and update summary script

### DIFF
--- a/scripts/weekly-summary.sh
+++ b/scripts/weekly-summary.sh
@@ -1,21 +1,46 @@
 #!/bin/bash
 # Weekly summary generator for IPTF Map
 # Outputs markdown suitable for TG/Twitter
+# Optionally saves to weekly-updates/ with --save flag
 
 set -e
+
+# Parse flags
+SAVE_OUTPUT=false
+while [[ "$1" == --* ]]; do
+    case "$1" in
+        --save) SAVE_OUTPUT=true; shift ;;
+        *) echo "Unknown flag: $1"; exit 1 ;;
+    esac
+done
 
 # Default to last 7 days
 START_DATE="${1:-$(date -v-7d +%Y-%m-%d 2>/dev/null || date -d '7 days ago' +%Y-%m-%d)}"
 END_DATE="${2:-$(date +%Y-%m-%d)}"
 
 REPO_URL="https://github.com/ethereum/iptf-map/blob/master"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT_DIR="$REPO_ROOT/weekly-updates"
 
 format_date() {
     date -j -f %Y-%m-%d "$1" +"%b %d" 2>/dev/null || date -d "$1" +"%b %d"
 }
 
-echo "IPTF Map Weekly Update ($(format_date "$START_DATE") - $(format_date "$END_DATE"))"
-echo ""
+# Initialize output file if saving
+if [ "$SAVE_OUTPUT" = true ]; then
+    OUTPUT_FILE="$OUTPUT_DIR/${END_DATE}.md"
+    mkdir -p "$OUTPUT_DIR"
+    : > "$OUTPUT_FILE"  # Clear file
+fi
+
+# Output function - writes to stdout and optionally to file
+out() {
+    echo "$@"
+    if [ "$SAVE_OUTPUT" = true ]; then
+        echo "$@" >> "$OUTPUT_FILE"
+    fi
+}
 
 # Get commits in date range
 COMMITS=$(git log --since="$START_DATE" --until="$END_DATE 23:59:59" --oneline --no-merges 2>/dev/null || true)
@@ -25,53 +50,86 @@ if [ -z "$COMMITS" ]; then
     exit 0
 fi
 
-# Extract new patterns (feat commits with pattern in scope)
+# Header
+if [ "$SAVE_OUTPUT" = true ]; then
+    out "# IPTF Map Weekly Summary - $(format_date "$START_DATE") - $(format_date "$END_DATE")"
+    out ""
+    out "## Telegram Post"
+    out ""
+    out '```'
+fi
+
+out "📢 IPTF Map Weekly Update"
+out ""
+
+# Count changes for summary line
+PATTERN_COUNT=$(echo "$COMMITS" | grep -cE "feat\(pattern" || echo 0)
+VENDOR_COUNT=$(echo "$COMMITS" | grep -cE "feat\(vendor" || echo 0)
+OTHER_COUNT=$(echo "$COMMITS" | grep -vcE "feat\((pattern|vendor)" || echo 0)
+
+# Build summary
+SUMMARY=""
+[ "$PATTERN_COUNT" -gt 0 ] && SUMMARY="${PATTERN_COUNT} new pattern(s)"
+[ "$VENDOR_COUNT" -gt 0 ] && SUMMARY="${SUMMARY}${SUMMARY:+, }${VENDOR_COUNT} new vendor(s)"
+[ "$OTHER_COUNT" -gt 0 ] && SUMMARY="${SUMMARY}${SUMMARY:+, and }improvements"
+out "$SUMMARY."
+out ""
+out "Full changelog: ${REPO_URL}/CHANGELOG.md"
+out ""
+
+# Extract new patterns
 PATTERN_COMMITS=$(echo "$COMMITS" | grep -E "feat\(pattern" || true)
 if [ -n "$PATTERN_COMMITS" ]; then
-    echo "New patterns:"
+    out "New patterns:"
     echo "$PATTERN_COMMITS" | while read -r line; do
-        # Extract the pattern name from message
-        NAME=$(echo "$line" | sed 's/^[a-f0-9]* //' | sed 's/feat(patterns): add //' | sed 's/ pattern.*//' | sed 's/ (#[0-9]*)$//')
+        NAME=$(echo "$line" | sed 's/^[a-f0-9]* //' | sed 's/feat(patterns\{0,1\}): add //' | sed 's/ pattern.*//' | sed 's/ (#[0-9]*)$//')
         SLUG=$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
-
-        # Check if file exists
         if [ -f "patterns/pattern-${SLUG}.md" ]; then
-            echo "- [${NAME}](patterns/pattern-${SLUG}.md)"
+            out "• ${NAME} - ${REPO_URL}/patterns/pattern-${SLUG}.md"
         else
-            echo "- ${NAME}"
+            out "• ${NAME}"
         fi
     done
-    echo ""
+    out ""
 fi
 
 # Extract new vendors
 VENDOR_COMMITS=$(echo "$COMMITS" | grep -E "feat\(vendor" || true)
 if [ -n "$VENDOR_COMMITS" ]; then
-    echo "New vendors:"
+    out "New vendors:"
     echo "$VENDOR_COMMITS" | while read -r line; do
-        NAME=$(echo "$line" | sed 's/^[a-f0-9]* //' | sed 's/feat(vendor): //' | sed 's/ (#[0-9]*)$//')
+        NAME=$(echo "$line" | sed 's/^[a-f0-9]* //' | sed 's/feat(vendor): //' | sed 's/^add //' | sed 's/ (#[0-9]*)$//')
         SLUG=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
-
         if [ -f "vendors/${SLUG}.md" ]; then
-            echo "- [${NAME}](vendors/${SLUG}.md)"
+            out "• ${NAME} - ${REPO_URL}/vendors/${SLUG}.md"
         else
-            echo "- ${NAME}"
+            out "• ${NAME}"
         fi
     done
-    echo ""
+    out ""
 fi
 
-# Extract improvements (fix, docs, chore - excluding pattern/vendor additions)
+# Extract improvements
 OTHER_COMMITS=$(echo "$COMMITS" | grep -vE "feat\((pattern|vendor)" | head -5 || true)
 if [ -n "$OTHER_COMMITS" ]; then
-    echo "Improvements:"
+    out "Improvements:"
     echo "$OTHER_COMMITS" | while read -r line; do
         MSG=$(echo "$line" | sed 's/^[a-f0-9]* //' | sed 's/^[a-z]*([^)]*): //' | sed 's/^[a-z]*: //' | sed 's/ (#[0-9]*)$//')
         if [ -n "$MSG" ]; then
-            echo "- ${MSG}"
+            out "• ${MSG}"
         fi
     done
-    echo ""
+    out ""
 fi
 
-echo "Full changelog: ${REPO_URL}/CHANGELOG.md"
+out "Questions or feedback? Drop them here 👇"
+
+if [ "$SAVE_OUTPUT" = true ]; then
+    out '```'
+    out ""
+    out "---"
+    out ""
+    out "## Notes"
+    out "- Generated with: \`./scripts/weekly-summary.sh --save ${START_DATE} ${END_DATE}\`"
+    echo "Saved to: $OUTPUT_FILE"
+fi

--- a/weekly-updates/2026-01-16.md
+++ b/weekly-updates/2026-01-16.md
@@ -1,0 +1,70 @@
+# IPTF Map Weekly Summary - Jan 9-16, 2026
+
+## Telegram Post
+
+```
+IPTF Map Weekly Update
+
+3 new privacy patterns, 1 new vendor, and infrastructure improvements.
+
+Full changelog: https://github.com/ethereum/iptf-map/blob/master/CHANGELOG.md
+
+New patterns:
+• Threshold encrypted mempool - https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-threshold-encrypted-mempool.md
+• TEE-based privacy - https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-tee-based-privacy.md
+• Private transaction broadcasting - https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-transaction-broadcasting.md
+
+New vendor:
+• Fhenix (FHE privacy) - https://github.com/ethereum/iptf-map/blob/master/vendors/fhenix.md
+
+Improvements:
+• CI with pattern validation and link checking
+• Private bond PoC updates - https://github.com/ethereum/iptf-map/blob/master/approaches/approach-private-bonds.md
+• Q1 2026 PRD for documentation initiative
+
+Questions or feedback? Drop them here.
+```
+
+---
+
+## X/Twitter Posts (3-tweet thread)
+
+### Tweet 1 (Main)
+```
+IPTF Map weekly update
+
+3 new privacy patterns:
+• Threshold encrypted mempool
+• TEE-based privacy
+• Private transaction broadcasting
+
+Plus: Fhenix vendor, CI improvements, private bond PoC updates.
+
+See thread for details
+```
+
+### Tweet 2 (Reply - Details)
+```
+What these patterns do:
+
+• Threshold encrypted mempool - MEV protection via committee decryption
+• TEE-based privacy - hardware enclaves for confidential compute
+• Private tx broadcasting - prevents IP/timing correlation
+```
+
+### Tweet 3 (Reply - Links)
+```
+Links:
+
+• Threshold mempool: https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-threshold-encrypted-mempool.md
+• TEE privacy: https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-tee-based-privacy.md
+• Private broadcasting: https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-transaction-broadcasting.md
+• Fhenix: https://github.com/ethereum/iptf-map/blob/master/vendors/fhenix.md
+
+Changelog: https://github.com/ethereum/iptf-map/blob/master/CHANGELOG.md
+```
+
+---
+
+## Notes
+- RFPs (7 new proposals) excluded - save for next week

--- a/weekly-updates/README.md
+++ b/weekly-updates/README.md
@@ -1,0 +1,20 @@
+# Weekly Updates
+
+This directory contains weekly summary posts for the IPTF Map, ready to share on social media.
+
+## Format
+
+Each file is named `YYYY-MM-DD.md` (date of the summary's end date) and contains:
+- Telegram post (longer format)
+- X/Twitter posts (main tweet + reply thread)
+- Notes for next week
+
+## Usage
+
+Copy the relevant section from the markdown file and paste into your platform of choice.
+
+## Archive
+
+| Date | Highlights |
+|------|------------|
+| [2026-01-16](2026-01-16.md) | 3 new patterns (threshold encrypted mempool, TEE-based privacy, private transaction broadcasting), Fhenix vendor |


### PR DESCRIPTION
## Summary
- Added `weekly-updates/` directory for storing ready-to-post social media summaries
- Enhanced `scripts/weekly-summary.sh` with `--save` flag to output formatted updates
- First weekly update (Jan 9-16, 2026) with Telegram and Twitter thread formats

## Test plan
- [ ] Verify script runs: `./scripts/weekly-summary.sh 2026-01-09 2026-01-16`
- [ ] Verify save flag: `./scripts/weekly-summary.sh --save 2026-01-09 2026-01-16`
- [ ] Review output formats in `weekly-updates/2026-01-16.md`