### PR TITLE
perf(ci): optimize link checking for faster PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,20 @@ jobs:
           CI_MODE: strict
         continue-on-error: true
 
-      - name: Check markdown links
+      - name: Get changed markdown files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            **/*.md
+
+      - name: Check markdown links (changed files only)
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
           config-file: '.github/markdown-link-check-config.json'
+          check-modified-files-only: 'yes'
         continue-on-error: true
 
       - name: Markdown linting

--- a/.github/workflows/link-check-full.yml
+++ b/.github/workflows/link-check-full.yml
@@ -1,0 +1,29 @@
+name: Full Link Check
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6am UTC
+  workflow_dispatch:      # Manual trigger from Actions tab
+
+jobs:
+  full-link-check:
+    runs-on: ubuntu-latest
+    name: Check All Links
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check all markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'no'
+          config-file: '.github/markdown-link-check-config.json'
+        # No continue-on-error - failures should be visible
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Full Link Check Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Checked all markdown files in the repository." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- PR link checks now only scan changed markdown files (not entire repo)
- Added daily scheduled workflow for comprehensive full-repo link checks
- Full check also available via manual trigger in Actions tab

## Test plan

- [ ] Verify PR CI runs faster (link check step processes fewer files)
- [ ] After merge, manually trigger "Full Link Check" workflow from Actions tab
- [ ] Verify daily scheduled run appears in Actions history

🤖 Generated with [Claude Code](https://claude.com/claude-code)