### PR TITLE
feat(vendors): add iExec confidential computing entry

### DIFF
--- a/vendors/iexec.md
+++ b/vendors/iexec.md
@@ -64,8 +64,8 @@ Core components include PoCo (Proof-of-Contribution), TEE-enabled worker nodes (
 
 - Reliance on hardware security assumptions (Intel SGX trust model)
 - Centralization considerations around TEE hardware supply
-- Performance constraints for heavy workloads
-- Evolving regulatory landscape for confidential compute
+- Workloads requiring GPUs or specialized hardware accelerators cannot run inside SGX enclaves
+- Very large memory workloads are constrained by enclave memory limits
 
 ## Links
 


### PR DESCRIPTION
## What are you adding?

- [x] Vendor/Protocol
- [ ] Enterprise Use Case
- [ ] Update to existing content
- [ ] Other

## Description

Add iExec to the vendors list as a confidential computing provider leveraging TEE for secure off-chain computation.

## Checklist

- [x] I've checked this doesn't duplicate existing content
- [x] All links work
- [x] Info is accurate
