### PR TITLE
fix(vendor): address ey comment on nightfall vendor card

### DIFF
--- a/vendors/ey.md
+++ b/vendors/ey.md
@@ -43,7 +43,7 @@ Target segments include multinational corporations, financial institutions
 - UltraPlonk proof system with no per-circuit trusted setup
 - supporting ERC20/721/1155/3525 standards
 - RESTful APIs for deposit, transfer, withdraw operations with X-Request-ID tracking
-- Integration with LocalWallet, AzureWallet, and HSM for enterprise key management
+- Integration with LocalWallet and AzureWallet for enterprise key management
 - Sophisticated chain reorganization handling and immediate finality from ZK rollup architecture.
 
 ### Strengths


### PR DESCRIPTION
This pull request makes a small change to the vendor documentation, specifically updating the list of supported enterprise key management integrations.

* Removed integration with HSM from the list of supported enterprise key management solutions, now only mentioning `LocalWallet` and `AzureWallet`.