### PR TITLE
feat(vendor): Add Partisia Blockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the IPTF Map are documented here.
 
 ### Added
 
-- feat(vendor): [Vendor: Partisia Blockchain](vendors/partisia-blockchain.md) ([#123](https://github.com/ethereum/iptf-map/issues/123))
+- feat(vendor): [Vendor: Partisia Blockchain](vendors/partisia-blockchain.md) ([#128](https://github.com/ethereum/iptf-map/issues/128))
 - feat(pattern): [TLS Payment Bridge](patterns/pattern-tls-payment-bridge.md) — trust-minimized fiat-to-onchain swaps via zk-TLS proofs on instant payment rails ([#88](https://github.com/ethereum/iptf-map/issues/88))
 - feat(vendor): [Peer](vendors/peer.md) — P2P fiat-to-crypto onramp using TLSNotary proofs ([#88](https://github.com/ethereum/iptf-map/issues/88))
 - feat(domain): [Post-Quantum Threats](domains/post-quantum.md) — PQ threat landscape, Ethereum layer analysis, and application-layer breakage index ([#121](https://github.com/ethereum/iptf-map/pull/121))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the IPTF Map are documented here.
 
 ### Added
 
+- feat(vendor): [Vendor: Partisia Blockchain](vendors/partisia-blockchain.md) ([#123](https://github.com/ethereum/iptf-map/issues/123))
 - feat(pattern): [TLS Payment Bridge](patterns/pattern-tls-payment-bridge.md) — trust-minimized fiat-to-onchain swaps via zk-TLS proofs on instant payment rails ([#88](https://github.com/ethereum/iptf-map/issues/88))
 - feat(vendor): [Peer](vendors/peer.md) — P2P fiat-to-crypto onramp using TLSNotary proofs ([#88](https://github.com/ethereum/iptf-map/issues/88))
 - feat(domain): [Post-Quantum Threats](domains/post-quantum.md) — PQ threat landscape, Ethereum layer analysis, and application-layer breakage index ([#121](https://github.com/ethereum/iptf-map/pull/121))

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -96,6 +96,3 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 - [Documentation](https://partisiablockchain.gitlab.io/documentation/index.html)
 - [Example contracts](https://gitlab.com/partisiablockchain/language/example-contracts)
 - [Cross-chain integration guide](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
-
-[^1]:  Institutional Privacy Task Force
-

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -1,0 +1,89 @@
+---
+title: "Vendor: Partisia Blockchain"
+status: draft
+---
+
+# Partisia Blockchain – Private Smart Contracts using Secure multi-party computation
+
+# What it is
+
+Partisia Blockchain (PBC) is a Layer 1 blockchain with a cross-chain bridge to Ethereum that allows for customizable MPC (multi-party computation) as a service to the Ethereum network. MPC is enabled as an integrated, core protocol component with orchestration of the computation through a combination of Ethereum and Partisia Blockchain smart contracts.
+
+PBC is a semi-permissioned blockchain, where all nodes (blockproducers, oracle,
+and MPC) have undergone a formal KYC check. PBC allows users to write
+regular smart contracts in Rust.
+
+# Fits Patterns
+
+- [MPC Custody](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-mpc-custody.md)
+- [Private Shared State](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-shared-state.md)
+- [Shielding](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-shielding.md)
+- [Pattern-hybrid-public-private-modes](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-hybrid-public-private-modes.md)
+- [Pattern-l2-privacy-evaluation](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-l2-privacy-evaluation.md)
+- [Pattern-modular-privacy-stack](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-modular-privacy-stack.md)
+- [Pattern-permissioned-ledger-interoperability](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-permissioned-ledger-interoperability.md)
+- [Pattern-pretrade-privacy-encryption](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-pretrade-privacy-encryption.md)
+- [Pattern-private-PvP-stablecoins-ERC-7573](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-pvp-stablecoins-erc7573.md)
+- [Pattern-private-stablecoin-shielded-payments](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-stablecoin-shielded-payments.md)
+- [Pattern-private-vaults](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-vaults.md)
+
+
+# Not a substitute for
+
+- ZKp based techniques where data must be verifiable unconditionally and non-interactively.
+- TEE
+- FHE
+
+# Architecture
+
+PBC’s private smart contract feature is enabled by a four-party, threshold one, MPC protocol. When deploying a private smart contract, the user can specify requirements for jurisdiction etc. which is then used when picking the set of KYC’ed nodes that are tasked with keeping the computation state secret, as well as running the MPC. PBC’s execution engine feature can be used to further control which nodes run the computation, as well as what the MPC protocol looks like.
+
+Access to MPC from Ethereum is available through a MPC backed, collateralized cross-chain bridge between Ethereum and Partisia Blockchain
+
+Gas for the MPC computation is payable in Eth or USDT, usually bridged into Partisia Blockchain
+
+More details on Crosschain can be found here \- [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
+
+More details on Gas in Partisia can be found here \- [https://partisiablockchain.gitlab.io/documentation/pbc-fundamentals/byoc/byoc.html](https://partisiablockchain.gitlab.io/documentation/pbc-fundamentals/byoc/byoc.html)
+
+# Privacy domains (if applicable)
+
+- Programmable privacy allowing Turing complete computations
+- MPC orchestrated using a combination of Ethereum and Partisia Blockchain
+
+# Enterprise demand and use cases
+
+- Compliant shielded transactions
+- Programmable MPC key custody for enterprise custody
+- Analysis of secret data (health care, AML, Credit rating, supply chain, etc)
+- MPC based secret bid auctions for RWA, Orderbooks, etc
+- Hybrid Public / Private blockchain model
+- Private Shared State for financial organization (and others)
+- Selective Disclosure
+
+# Technical details
+
+- Four party, one corruption, actively secure MPC protocol with guaranteed output.
+- Smart contract language (both public and private) is a subset of rust.
+- Public smart contracts are compiled to WASM; private smart contracts are compiled to a custom circuit-like language.
+
+# Strengths
+
+- MPC protocols are interoperable with programmable platform protocol.
+- Cross chain bridge enabling orchestration of Multi-party Computation (MPC) on Ethereum, with gas payable using USDT or ETH.
+
+# Risks and open questions
+
+- One threat model supported out of the box (four parties, one corruption)
+- Current network supports GDPR compliance.  Other regions require additional node buildout
+- Integration to Ethereum.  Not an L2 but also not a side-chain.
+- Protocol based.  Not CPU intensive like TEE or FHE but sensitive to network usage.
+
+# Links
+
+- [https://partisiablockchain.gitlab.io/documentation/index.html](https://partisiablockchain.gitlab.io/documentation/index.html)
+- [https://gitlab.com/partisiablockchain/language/example-contracts](https://gitlab.com/partisiablockchain/language/example-contracts)
+- [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
+
+[^1]:  Institutional Privacy Task Force
+

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -92,9 +92,11 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 
 # Links
 
-- [https://partisiablockchain.gitlab.io/documentation/index.html](https://partisiablockchain.gitlab.io/documentation/index.html)
-- [https://gitlab.com/partisiablockchain/language/example-contracts](https://gitlab.com/partisiablockchain/language/example-contracts)
-- [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
+- Official website: [https://partisiablockchain.com](https://partisiablockchain.com)
+- GitLab organization: [https://gitlab.com/partisiablockchain](https://gitlab.com/partisiablockchain)
+- Documentation: [https://partisiablockchain.gitlab.io/documentation/index.html](https://partisiablockchain.gitlab.io/documentation/index.html)
+- Example contracts: [https://gitlab.com/partisiablockchain/language/example-contracts](https://gitlab.com/partisiablockchain/language/example-contracts)
+- Cross-chain integration guide: [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
 
 [^1]:  Institutional Privacy Task Force
 

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -72,6 +72,17 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 - MPC protocols are interoperable with programmable platform protocol.
 - Cross chain bridge enabling orchestration of Multi-party Computation (MPC) on Ethereum, with gas payable using USDT or ETH.
 
+## CROPS profile
+
+| Product | CR | OS | Privacy | Security | Context |
+|---------|----|----|---------|----------|---------|
+| Partisia Blockchain | low | yes | full | medium | both |
+
+- **CR**: Low — all nodes (block producers, oracle, MPC) undergo formal KYC, creating identifiable gatekeepers. While protocol-level exit exists via the cross-chain bridge, node operators can exclude users or delay operations.
+- **OS**: Yes — entire codebase including node software and MPC implementation is available under AGPL license, providing full auditability and forkability with strong copyleft protections.
+- **Privacy**: Full — MPC operations are private by default with no party learning more than the protocol requires. Privacy guarantees are controlled by the smart contract developer, with no mandatory disclosure to node operators.
+- **Security**: Medium — security relies on honest-majority MPC (four-party, one-corruption threshold), cross-chain bridge integrity, and active node network. The MPC protocol has guaranteed output but requires operational trust in KYC'ed node operators.
+
 # Risks and open questions
 
 - One threat model supported out of the box (four parties, one corruption)

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -7,11 +7,9 @@ status: draft
 
 # What it is
 
-Partisia Blockchain (PBC) is a Layer 1 blockchain with a cross-chain bridge to Ethereum that allows for customizable MPC (multi-party computation) as a service to the Ethereum network. MPC is enabled as an integrated, core protocol component with orchestration of the computation through a combination of Ethereum and Partisia Blockchain smart contracts.
+Partisia Blockchain (PBC) is a Layer 1 blockchain that provides MPC (multi-party computation) as a service to Ethereum applications through a collateralized cross-chain bridge. PBC extends Ethereum's privacy capabilities by enabling programmable MPC orchestrated via Ethereum smart contracts, supporting institutional privacy patterns including ERC-7573 private stablecoin transfers, MPC custody, and private shared state for enterprise use cases. MPC is enabled as an integrated, core protocol component with orchestration of the computation through a combination of Ethereum and Partisia Blockchain smart contracts.
 
-PBC is a semi-permissioned blockchain, where all nodes (blockproducers, oracle,
-and MPC) have undergone a formal KYC check. PBC allows users to write
-regular smart contracts in Rust.
+PBC is a semi-permissioned blockchain, where all nodes (block producers, oracle, and MPC) have undergone a formal KYC check. PBC allows users to write regular smart contracts in Rust.
 
 # Fits Patterns
 
@@ -36,11 +34,11 @@ regular smart contracts in Rust.
 
 # Architecture
 
-PBC’s private smart contract feature is enabled by a four-party, threshold one, MPC protocol. When deploying a private smart contract, the user can specify requirements for jurisdiction etc. which is then used when picking the set of KYC’ed nodes that are tasked with keeping the computation state secret, as well as running the MPC. PBC’s execution engine feature can be used to further control which nodes run the computation, as well as what the MPC protocol looks like.
+PBC's private smart contract feature is enabled by a four-party, threshold one, MPC protocol. When deploying a private smart contract, the user can specify requirements for jurisdiction etc. which is then used when picking the set of KYC'ed nodes that are tasked with keeping the computation state secret, as well as running the MPC. PBC's execution engine feature can be used to further control which nodes run the computation, as well as what the MPC protocol looks like.
 
-Access to MPC from Ethereum is available through a MPC-backed, collateralized cross-chain bridge between Ethereum and Partisia Blockchain
+Ethereum applications access MPC computation through a MPC-backed, collateralized cross-chain bridge. This architecture enables Ethereum-based enterprises to leverage programmable MPC for privacy-preserving operations while maintaining Ethereum as the primary settlement and orchestration layer.
 
-Gas for the MPC computation is payable in Eth or USDT, usually bridged into Partisia Blockchain
+Gas for the MPC computation is payable in ETH or USDT, usually bridged into Partisia Blockchain.
 
 More details on cross-chain can be found here \- [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
 
@@ -81,14 +79,15 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 - **CR**: Low — all nodes (block producers, oracle, MPC) undergo formal KYC, creating identifiable gatekeepers. While protocol-level exit exists via the cross-chain bridge, node operators can exclude users or delay operations.
 - **OS**: Yes — entire codebase including node software and MPC implementation is available under AGPL license, providing full auditability and forkability with strong copyleft protections.
 - **Privacy**: Full — MPC operations are private by default with no party learning more than the protocol requires. Privacy guarantees are controlled by the smart contract developer, with no mandatory disclosure to node operators.
-- **Security**: Medium — security relies on honest-majority MPC (four-party, one-corruption threshold), cross-chain bridge integrity, and active node network. The MPC protocol has guaranteed output but requires operational trust in KYC'ed node operators.
+- **Security**: Medium — security relies on honest-majority MPC (four-party, one-corruption threshold), cross-chain bridge integrity, and active node network. Upgrade mechanism uses on-chain voting with two-thirds-plus-one majority among KYC'ed node operators. No public audit reports, bug bounty program, or documented security incidents; security depends on operational trust in node operators and governance contract correctness.
+- **Context**: Both i2i and i2u — supports institution-to-institution use cases (private shared state, compliant institutional settlement) and institution-to-user scenarios (shielded transactions, programmable custody).
 
 # Risks and open questions
 
 - One threat model supported out of the box (four parties, one corruption)
-- Current network supports GDPR compliance.  Other regions require additional node buildout
-- Integration to Ethereum.  Not an L2 but also not a side-chain.
-- Protocol based.  Not CPU intensive like TEE or FHE but sensitive to network usage.
+- Current network supports GDPR compliance. Other regions require additional node buildout
+- Separate L1 architecture with bridge-based integration — not an L2 but also not a sidechain; Ethereum benefit depends on bridge orchestration and institutional adoption of Ethereum-based privacy patterns
+- Protocol based. Not CPU intensive like TEE or FHE but sensitive to network usage.
 
 # Links
 

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -11,19 +11,19 @@ Partisia Blockchain (PBC) is a Layer 1 blockchain that provides MPC (multi-party
 
 PBC is a semi-permissioned blockchain, where all nodes (block producers, oracle, and MPC) have undergone a formal KYC check. PBC allows users to write regular smart contracts in Rust.
 
-# Fits Patterns
+Fits with patterns (names only)
 
-- [MPC Custody](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-mpc-custody.md)
-- [Private Shared State](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-shared-state.md)
-- [Shielding](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-shielding.md)
-- [Pattern-hybrid-public-private-modes](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-hybrid-public-private-modes.md)
-- [Pattern-l2-privacy-evaluation](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-l2-privacy-evaluation.md)
-- [Pattern-modular-privacy-stack](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-modular-privacy-stack.md)
-- [Pattern-permissioned-ledger-interoperability](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-permissioned-ledger-interoperability.md)
-- [Pattern-pretrade-privacy-encryption](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-pretrade-privacy-encryption.md)
-- [Pattern-private-PvP-stablecoins-ERC-7573](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-pvp-stablecoins-erc7573.md)
-- [Pattern-private-stablecoin-shielded-payments](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-stablecoin-shielded-payments.md)
-- [Pattern-private-vaults](https://github.com/ethereum/iptf-map/blob/master/patterns/pattern-private-vaults.md)
+- MPC Custody
+- Private Shared State
+- Shielding
+- Pattern-hybrid-public-private-modes
+- Pattern-l2-privacy-evaluation
+- Pattern-modular-privacy-stack
+- Pattern-permissioned-ledger-interoperability
+- Pattern-pretrade-privacy-encryption
+- Pattern-private-PvP-stablecoins-ERC-7573
+- Pattern-private-stablecoin-shielded-payments
+- Pattern-private-vaults
 
 
 # Not a substitute for

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -92,11 +92,11 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 
 # Links
 
-- Official website: [https://partisiablockchain.com](https://partisiablockchain.com)
-- GitLab organization: [https://gitlab.com/partisiablockchain](https://gitlab.com/partisiablockchain)
-- Documentation: [https://partisiablockchain.gitlab.io/documentation/index.html](https://partisiablockchain.gitlab.io/documentation/index.html)
-- Example contracts: [https://gitlab.com/partisiablockchain/language/example-contracts](https://gitlab.com/partisiablockchain/language/example-contracts)
-- Cross-chain integration guide: [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
+- [Official website](https://partisiablockchain.com)
+- [GitLab organization](https://gitlab.com/partisiablockchain)
+- [Documentation](https://partisiablockchain.gitlab.io/documentation/index.html)
+- [Example contracts](https://gitlab.com/partisiablockchain/language/example-contracts)
+- [Cross-chain integration guide](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
 
 [^1]:  Institutional Privacy Task Force
 

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -11,7 +11,7 @@ Partisia Blockchain (PBC) is a Layer 1 blockchain that provides MPC (multi-party
 
 PBC is a semi-permissioned blockchain, where all nodes (block producers, oracle, and MPC) have undergone a formal KYC check. PBC allows users to write regular smart contracts in Rust.
 
-Fits with patterns (names only)
+Fits with patterns
 
 - MPC Custody
 - Private Shared State
@@ -28,13 +28,13 @@ Fits with patterns (names only)
 
 # Not a substitute for
 
-- ZKP-based techniques where data must be verifiable unconditionally and non-interactively.
+- Zero-knowledge proof-based techniques where data must be verifiable unconditionally and non-interactively.
 - TEE
 - FHE
 
 # Architecture
 
-PBC's private smart contract feature is enabled by a four-party, threshold one, MPC protocol. When deploying a private smart contract, the user can specify requirements for jurisdiction etc. which is then used when picking the set of KYC'ed nodes that are tasked with keeping the computation state secret, as well as running the MPC. PBC's execution engine feature can be used to further control which nodes run the computation, as well as what the MPC protocol looks like.
+PBC's private smart contract feature is enabled by a four-party, threshold-one, MPC protocol. When deploying a private smart contract, the user can specify requirements for jurisdiction etc. which is then used when picking the set of KYC'ed nodes that are tasked with keeping the computation state secret, as well as running the MPC. PBC's execution engine feature can be used to further control which nodes run the computation, as well as what the MPC protocol looks like.
 
 Ethereum applications access MPC computation through a MPC-backed, collateralized cross-chain bridge. This architecture enables Ethereum-based enterprises to leverage programmable MPC for privacy-preserving operations while maintaining Ethereum as the primary settlement and orchestration layer.
 
@@ -46,7 +46,7 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 
 # Privacy domains (if applicable)
 
-- Programmable privacy allowing Turing complete computations
+- Programmable privacy allowing Turing-complete computations
 - MPC orchestrated using a combination of Ethereum and Partisia Blockchain
 
 # Enterprise demand and use cases
@@ -54,14 +54,14 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 - Compliant shielded transactions
 - Programmable MPC key custody for enterprise custody
 - Analysis of secret data (health care, AML, Credit rating, supply chain, etc.)
-- MPC based secret bid auctions for RWA, Orderbooks, etc.
+- MPC-based secret bid auctions for RWA, Orderbooks, etc.
 - Hybrid Public / Private blockchain model
 - Private Shared State for financial organization (and others)
 - Selective Disclosure
 
 # Technical details
 
-- Four party, one corruption, actively secure MPC protocol with guaranteed output.
+- Four-party, one-corruption, actively secure MPC protocol with guaranteed output.
 - Smart contract language (both public and private) is a subset of rust.
 - Public smart contracts are compiled to WASM; private smart contracts are compiled to a custom circuit-like language.
 
@@ -84,7 +84,7 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 
 # Risks and open questions
 
-- One threat model supported out of the box (four parties, one corruption)
+- One threat model supported out of the box (four-party, one-corruption)
 - Current network supports GDPR compliance. Other regions require additional node buildout
 - Separate L1 architecture with bridge-based integration — not an L2 but also not a sidechain; Ethereum benefit depends on bridge orchestration and institutional adoption of Ethereum-based privacy patterns
 - Protocol based. Not CPU intensive like TEE or FHE but sensitive to network usage.

--- a/vendors/partisia-blockchain.md
+++ b/vendors/partisia-blockchain.md
@@ -30,7 +30,7 @@ regular smart contracts in Rust.
 
 # Not a substitute for
 
-- ZKp based techniques where data must be verifiable unconditionally and non-interactively.
+- ZKP-based techniques where data must be verifiable unconditionally and non-interactively.
 - TEE
 - FHE
 
@@ -38,11 +38,11 @@ regular smart contracts in Rust.
 
 PBC’s private smart contract feature is enabled by a four-party, threshold one, MPC protocol. When deploying a private smart contract, the user can specify requirements for jurisdiction etc. which is then used when picking the set of KYC’ed nodes that are tasked with keeping the computation state secret, as well as running the MPC. PBC’s execution engine feature can be used to further control which nodes run the computation, as well as what the MPC protocol looks like.
 
-Access to MPC from Ethereum is available through a MPC backed, collateralized cross-chain bridge between Ethereum and Partisia Blockchain
+Access to MPC from Ethereum is available through a MPC-backed, collateralized cross-chain bridge between Ethereum and Partisia Blockchain
 
 Gas for the MPC computation is payable in Eth or USDT, usually bridged into Partisia Blockchain
 
-More details on Crosschain can be found here \- [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
+More details on cross-chain can be found here \- [https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html](https://partisiablockchain.gitlab.io/documentation/smart-contracts/pbc-as-second-layer/partisia-blockchain-as-second-layer.html)
 
 More details on Gas in Partisia can be found here \- [https://partisiablockchain.gitlab.io/documentation/pbc-fundamentals/byoc/byoc.html](https://partisiablockchain.gitlab.io/documentation/pbc-fundamentals/byoc/byoc.html)
 
@@ -55,8 +55,8 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 
 - Compliant shielded transactions
 - Programmable MPC key custody for enterprise custody
-- Analysis of secret data (health care, AML, Credit rating, supply chain, etc)
-- MPC based secret bid auctions for RWA, Orderbooks, etc
+- Analysis of secret data (health care, AML, Credit rating, supply chain, etc.)
+- MPC based secret bid auctions for RWA, Orderbooks, etc.
 - Hybrid Public / Private blockchain model
 - Private Shared State for financial organization (and others)
 - Selective Disclosure
@@ -70,7 +70,7 @@ More details on Gas in Partisia can be found here \- [https://partisiablockchain
 # Strengths
 
 - MPC protocols are interoperable with programmable platform protocol.
-- Cross chain bridge enabling orchestration of Multi-party Computation (MPC) on Ethereum, with gas payable using USDT or ETH.
+- Cross-chain bridge enabling orchestration of Multi-party Computation (MPC) on Ethereum, with gas payable using USDT or ETH.
 
 ## CROPS profile
 


### PR DESCRIPTION

## What are you adding?

- [x] Vendor/Protocol
- [ ] Enterprise Use Case
- [ ] Update to existing content
- [ ] Other

## Description

Adding Partisia Blockchain as a vendor to be used as a privacy layer for Ethereum and in enterprise use cases.

This succeeds <https://github.com/ethereum/iptf-map/pull/114>, as the owner of the PR has resigned. Feel free to remove that PR. This PR solves the issues that CodeRabbit found in the previous PR. 

## Checklist

- [x] I've checked this doesn't duplicate existing content
- [x] All links work
- [x] Info is accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added draft vendor documentation for Partisia Blockchain: introduces its Layer‑1 MPC-enabled private smart contract model, collateralized cross‑chain bridge to Ethereum, node governance and KYC‑checked participation, execution and privacy patterns, gas/payment options, compilation/execution notes, a CROPS product assessment, listed risks and open questions, and reference links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->