### PR TITLE
feat(pattern): forced withdrawal / L1 escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the IPTF Map are documented here.
 ### Added
 
 #### Patterns
+- feat(pattern): [Forced Withdrawal](patterns/pattern-forced-withdrawal.md) — L1 escape hatch for asset recovery without operator cooperation ([#125](https://github.com/ethereum/iptf-map/issues/125))
 - feat(pattern): [TLS Payment Bridge](patterns/pattern-tls-payment-bridge.md) — trust-minimized fiat-to-onchain swaps via zk-TLS proofs on instant payment rails ([#88](https://github.com/ethereum/iptf-map/issues/88))
 - feat(pattern): [Native Account Abstraction](patterns/pattern-native-account-abstraction.md) — EIP-8141 modular verification logic for PQ auth agility ([#121](https://github.com/ethereum/iptf-map/pull/121))
 - feat(pattern): [ZK Proof Systems](patterns/pattern-zk-proof-systems.md) — taxonomy of proving systems with PQ safety analysis ([#121](https://github.com/ethereum/iptf-map/pull/121))

--- a/approaches/approach-private-payments.md
+++ b/approaches/approach-private-payments.md
@@ -68,7 +68,7 @@ These problems interact because traditional payment transparency conflicts with 
 **MPC-Based Privacy:**
 
 - Multi-party computation nodes jointly process transactions without any single party seeing plaintext
-- Combines MPC with ZK proofs (co-SNARKs) for on-chain verification of private state transitions
+- Combines MPC with zero-knowledge proofs (co-SNARKs) for on-chain verification of private state transitions
 - [co-SNARKs (Collaborative Proving)](../patterns/pattern-co-snark.md) pattern, See also [TACEO Merces](../vendors/taceo-merces.md)
 - Best for: Amount confidentiality where counterparty relationships are already known (e.g., bilateral settlement)
 - Trade-off: No sender/receiver anonymity; addresses remain public on-chain
@@ -106,7 +106,7 @@ These problems interact because traditional payment transparency conflicts with 
 
 ### PoC Validation
 
-Two approaches were implemented as proof-of-concept: an L1 shielded pool (UTXO model with Noir/[UltraHonk](https://github.com/AztecProtocol/barretenberg)) and a Plasma/Intmax2 stateless rollup ([Plonky2](https://github.com/0xPolygonZero/plonky2)). Both use dual-key architecture (spending + viewing) and attestation-gated entry via ZK proof of KYC.
+Two approaches were implemented as proof-of-concept: an L1 shielded pool (UTXO model with Noir/[UltraHonk](https://github.com/AztecProtocol/barretenberg)) and a Plasma/Intmax2 stateless rollup ([Plonky2](https://github.com/0xPolygonZero/plonky2)). Both use dual-key architecture (spending + viewing) and attestation-gated entry via zero-knowledge proof of KYC.
 
 > **Note:** Benchmarks below are indicative measurements from PoC testing, not production reference numbers. Implementers should run their own benchmarks with domain-specific configuration.
 
@@ -129,10 +129,11 @@ Two approaches were implemented as proof-of-concept: an L1 shielded pool (UTXO m
 #### Cross-Cutting Findings
 
 - **Dual-key architecture** (spending + viewing) works in both models, confirming selective disclosure is practical without granting transfer authority
-- **Attestation-gated entry** via ZK proof of Merkle tree inclusion is feasible (MAX_ATTESTATION_TREE_DEPTH=20, supporting ~1M participants, configurable for larger participtants, but increases proving time)
+- **Attestation-gated entry** via zero-knowledge proof of Merkle tree inclusion is feasible (MAX_ATTESTATION_TREE_DEPTH=20, supporting ~1M participants, configurable for larger participants, but increases proving time)
 - **Network timing correlation** is unmitigated in both approaches; see [Network-Level Anonymity](../patterns/pattern-network-anonymity.md) for mitigation patterns
 - **Withdrawal to fresh addresses** requires a gas relayer since the recipient address may not have ETH for gas. Users can always withdraw directly (sacrificing privacy), but private withdrawal depends on relayer liveness and willingness to relay
 - **Multi-token transfers** require same-token constraints in circuits, confirming per-token shielded pools and liquidity fragmentation concerns
+- **Forced withdrawal fallback** — when relayers are unavailable or censoring, users need a way to bypass them and withdraw via an L1 escape hatch contract directly. See [Forced Withdrawal](../patterns/pattern-forced-withdrawal.md); privacy is weaker during forced exit (timing and destination address visible on-chain) but funds stay recoverable
 - **PlasmaBlind** (folding-scheme-based stateless plasma) is an emerging alternative to Plonky2 recursive proofs; see [PSE research](https://pse.dev/mastermap/ptr)
 
 ### Vendor Recommendations
@@ -199,12 +200,13 @@ Two approaches were implemented as proof-of-concept: an L1 shielded pool (UTXO m
 - **Shielded Pool:** No protocol-level operator needed; users interact directly with L1 contracts. Private transactions depend on a first/third-party gas relayer to avoid linking the sender's funded address
 - **Plasma/Intmax2:** Requires operator infrastructure for block building, proving, and withdrawal processing
 - **Consideration:** Operator economics and liveness guarantees must be addressed for production deployment
+- **Liveness fallback:** L2-based private payment solutions must implement [Forced Withdrawal](../patterns/pattern-forced-withdrawal.md) so users can recover funds on L1 when the operator is unresponsive. Plasma/Intmax2 already supports this via the L1 anchor contract's exit game (users submit a zero-knowledge proof of sufficient balance). L1 shielded pools (e.g., Railgun) do not need a separate escape hatch since users interact with L1 directly
 
 ### Open Questions
 
 **Partially Resolved by PoC:**
 
-1. **Stablecoin Issuer Integration:** Attestation-gated entry (ZK proof of KYC) demonstrates a viable compliance gating mechanism. Remaining: freeze/denylist integration within shielded pools.
+1. **Stablecoin Issuer Integration:** Attestation-gated entry (zero-knowledge proof of KYC) demonstrates a viable compliance gating mechanism. Remaining: freeze/denylist integration within shielded pools.
 
 2. **Liquidity Fragmentation:** Multi-token transfers require same-token constraints in circuits, confirming per-token shielded pools. Remaining: cross-pool atomic swaps and multi-asset circuit designs.
 
@@ -241,7 +243,7 @@ Two approaches were implemented as proof-of-concept: an L1 shielded pool (UTXO m
 
 - **Standards:** [ERC-3643](https://eips.ethereum.org/EIPS/eip-3643), [ERC-7573](https://ercs.ethereum.org/ERCS/erc-7573), [ISO 20022](https://www.iso20022.org/), [ERC-20](https://ercs.ethereum.org/ERCS/erc-20)
 - **Infrastructure:** [Railgun](https://railgun.org/), [Aztec Network](https://docs.aztec.network/), [Zama fhEVM](https://docs.zama.org/fhevm), [Intmax](https://www.intmax.io/)
-- **Patterns:** [Stateless Plasma Privacy](../patterns/pattern-plasma-stateless-privacy.md), [TEE-Based Privacy](../patterns/pattern-tee-based-privacy.md), [Private Stablecoin Shielded Payments](../patterns/pattern-private-stablecoin-shielded-payments.md), [Network-Level Anonymity](../patterns/pattern-network-anonymity.md)
+- **Patterns:** [Stateless Plasma Privacy](../patterns/pattern-plasma-stateless-privacy.md), [TEE-Based Privacy](../patterns/pattern-tee-based-privacy.md), [Private Stablecoin Shielded Payments](../patterns/pattern-private-stablecoin-shielded-payments.md), [Network-Level Anonymity](../patterns/pattern-network-anonymity.md), [Forced Withdrawal](../patterns/pattern-forced-withdrawal.md)
 - **Regulatory:** [MiCA Framework](../jurisdictions/eu-MiCA.md), [SEC - GENIUS Act](../jurisdictions/us-SEC.md)
 - **Related Approaches:** [Private Trade Settlement](../approaches/approach-private-trade-settlement.md), [Private Derivatives](../approaches/approach-private-derivatives.md)
 - **Reference Implementation:** [Private Payment PoC](https://github.com/ethereum/iptf-pocs/tree/master/pocs/private-payment)

--- a/approaches/approach-white-label-deployment.md
+++ b/approaches/approach-white-label-deployment.md
@@ -95,6 +95,7 @@ The following patterns from the Modular Privacy Stack provide building blocks:
 | Better technology emerges | Evaluate migration cost vs. benefit |
 | Regulatory change | Assess compliance gap; remediate or migrate |
 | Strategy shift | Graceful wind-down with user notification |
+| Operator/sequencer goes offline | [Forced Withdrawal](../patterns/pattern-forced-withdrawal.md) via L1 escape hatch; users self-exit within bounded time |
 
 ### Trade-offs
 
@@ -111,6 +112,7 @@ The following patterns from the Modular Privacy Stack provide building blocks:
 | Key personnel departure | Documentation, cross-training, vendor support |
 | Security vulnerability | Rapid patching process, per-layer isolation |
 | Bridge exploit | Insurance, security audits, rate limits |
+| Operator censorship or liveness failure | [Forced Withdrawal](../patterns/pattern-forced-withdrawal.md) via L1 escape hatch; timelock-based user self-exit |
 
 ## Example
 
@@ -129,4 +131,5 @@ The following patterns from the Modular Privacy Stack provide building blocks:
 - [TEE-Based Privacy](../patterns/pattern-tee-based-privacy.md) - Execution layer option
 - [Privacy L2s](../patterns/pattern-privacy-l2s.md) - L2 technologies for deployment
 - [Hybrid Public-Private Modes](../patterns/pattern-hybrid-public-private-modes.md) - Mode switching for compliance
+- [Forced Withdrawal](../patterns/pattern-forced-withdrawal.md) - L1 escape hatch for user-level exit when operator fails
 - [Aztec](../vendors/aztec.md), [Miden](../vendors/miden.md), [Fhenix](../vendors/fhenix.md) - Execution layer vendors

--- a/patterns/pattern-forced-withdrawal.md
+++ b/patterns/pattern-forced-withdrawal.md
@@ -1,0 +1,139 @@
+---
+title: "Pattern: Forced Withdrawal (L1 Escape Hatch)"
+status: draft
+maturity: PoC
+layer: hybrid
+privacy_goal: Let end users recover assets on L1 without operator cooperation, within bounded time
+assumptions: L1 escape hatch contract deployed, user retains note data and Merkle path, state roots anchored periodically on L1
+last_reviewed: 2026-04-08
+works-best-when:
+  - Users need a guaranteed exit from L2 or shielded pools even if the operator is offline or hostile
+  - Institutional deployments must demonstrate non-custodial protections for regulatory acceptance
+  - Censorship resistance is a hard requirement in I2U contexts
+avoid-when:
+  - L1-native operations where no intermediary can censor (e.g., direct shielding on L1)
+  - The cost of L1 proof verification exceeds the value of the assets at stake
+dependencies: [L1 anchor contract, zero-knowledge proof system, Merkle commitment tree]
+context: both
+crops_profile:
+  cr: high
+  os: yes
+  privacy: partial
+  security: high
+---
+
+## Intent
+
+When an L2 sequencer, relayer, or operator becomes unavailable, users need a unilateral path back to L1. Three pillars must hold simultaneously: the user has enough data to reconstruct their position (DA), an L1 contract accepts proof of that position and releases funds (verifier + liquidity), and the user can build the required proof on hardware they control (proving infra). If any one leg fails, the escape hatch is ineffective.
+
+## Ingredients
+
+### Data availability
+
+The user needs enough state to prove "I own X" against the last L1-anchored root.
+
+- **Account-model rollups:** Merkle proof of account balance. If transaction data is posted to L1 (calldata or blobs), anyone can reconstruct any account's state.
+- **UTXO/note-model privacy systems:** note preimage, nullifier secret, Merkle path. The on-chain data is encrypted; "available" does not mean "usable" without the user's decryption keys.
+- **Client-side architectures (Plasma):** the user is responsible for storing data locally. Some implementations offer backup storage servers (e.g., INTMAX), but these are convenience layers, not protocol guarantees. If local data is lost and no backup is reachable, funds are unrecoverable.
+
+Where the data lives determines the trust assumption:
+
+| Strategy                | Trust assumption                      | What breaks                       |
+| ----------------------- | ------------------------------------- | --------------------------------- |
+| L1 calldata             | Ethereum consensus                    | Nothing (permanent, expensive)    |
+| L1 blobs (EIP-4844)     | Ethereum + archival within ~18 days   | Pruned if nobody archives         |
+| External DA Layer       | DA Layer liveness + economic security | DA Layer offline or withholds     |
+| DA committee (Validium) | Honest committee majority             | Committee withholds; funds frozen |
+| Client-side             | The user                              | User loses data = funds gone      |
+
+For privacy systems, even with perfect DA, the user faces a five-step gap between "data exists" and "exit succeeds": raw byte access, data parsing (the rollup's compression format), state derivation, proof generation, L1 submission. Each step can independently block the exit.
+
+See [L2Beat DA Risk Framework](https://forum.l2beat.com/t/the-data-availability-risk-framework/318).
+
+### L1 verifier contract
+
+Three components on the L1 side:
+
+- **State root oracle:** stores the last verified L2 state root. For validity rollups, this root was accompanied by a zero-knowledge proof. For optimistic rollups, it survived a challenge period (typically 7 days).
+- **Proof verification:** accepts Merkle proofs (transparent systems) or zero-knowledge proofs (privacy systems) and checks them against the anchored root.
+- **Nullifier registry:** records completed withdrawals to prevent double-claims.
+
+Liquidity comes from the bridge contract's locked deposits. No new funds are created. Pending transactions after the last anchored root are unprovable and effectively lost. DeFi positions (LP tokens, lending, vaults) require custom "resolver" contracts to map complex storage slots to withdrawable amounts; most protocols have none, meaning those positions may be unescapable ([Zircuit, 2025](https://arxiv.org/html/2503.23986v1)).
+
+### Proving infrastructure
+
+What the user must produce depends on the construction:
+
+| Construction                   | Proof required                            | User-side effort                     |
+| ------------------------------ | ----------------------------------------- | ------------------------------------ |
+| Optimistic rollup              | None: sign an L2 tx, submit to L1 inbox | Trivial                              |
+| Validity rollup (transparent)  | Merkle inclusion proof                    | Low                                  |
+| Privacy rollup / shielded pool | Full zero-knowledge proof of commitment ownership     | High (seconds to minutes of compute) |
+
+For privacy escapes, users need circuit source code, access to proving keys or SRS artifacts (which can be large for Groth16), and sufficient local compute (roughly 0.5–3s native or 20–30s in browser WASM on current hardware). STARKs with transparent setup remove ceremony artifact dependencies. If Groth16 proving-key hosting goes offline, users may be unable to generate valid proofs.
+
+## Protocol (concise)
+
+1. User detects operator unresponsiveness or censorship (withdrawal requests ignored past a threshold)
+2. User retrieves the latest L1-anchored state root and their position data (note, Merkle path, nullifier secret for privacy systems; account state for transparent)
+3. User generates the required proof. Merkle witness for transparent systems, zero-knowledge proof for privacy systems
+4. User submits the proof and nullifier to the L1 escape hatch contract (directly or via any willing relayer)
+5. The contract verifies the proof against the anchored root, checks the nullifier is unspent, and starts the withdrawal
+6. A construction-dependent delay follows before the user can claim funds on L1. For optimistic rollups: a challenge period (typically 7 days) during which fraud proofs can invalidate the state root. For validity rollups: the state root is already proven, so the delay is an operator liveness timeout (hours to days, protocol-configurable) plus any safety buffer
+7. The nullifier is recorded on L1 to prevent double-withdrawal; the operator must account for this forced exit upon resumption
+
+## Guarantees
+
+How strong the escape guarantee is depends on the construction class:
+
+|                         | Validity rollup    | Optimistic rollup              | Privacy rollup                     | L1-native privacy      |
+| ----------------------- | ------------------ | ------------------------------ | ---------------------------------- | ---------------------- |
+| State freshness         | Latest proven root | Root must survive 7d challenge | Latest proven root                 | Real-time              |
+| Proof effort            | Merkle witness     | None (force-include tx)        | Full zero-knowledge proof                      | Full zero-knowledge proof (always) |
+| DA risk                 | Low if on-chain    | Low if on-chain                | High (encrypted state)             | None                   |
+| Escape without operator | Yes                | Yes                            | Partial (may need bonded proposer) | N/A: no operator     |
+
+When all three pillars hold:
+
+- **Bounded recovery time:** funds recoverable within a protocol-defined window, whether or not the operator comes back
+- **No operator cooperation:** the L1 contract enforces withdrawal autonomously
+- **Identity not required to exit:** for privacy systems, the zero-knowledge proof hides which commitment is being withdrawn. No KYC disclosure or transaction history reveal needed
+- **I2I:** neither counterparty can lock the other's funds by withholding operator cooperation
+- **I2U:** end users can exit on their own without institutional cooperation
+
+## Trade-offs
+
+**Upgrade risk:** 86% of 129 L2 projects allow instant contract upgrades without exit windows ([Ethical Risk Analysis of L2 Rollups, 2025](https://arxiv.org/html/2512.12732v1)). An escape hatch the operator can remove via upgrade provides no meaningful guarantee. [L2Beat Stages](https://medium.com/l2beat/introducing-stages-a-framework-to-evaluate-rollups-maturity-d290bb22befe) requires 7-day (Stage 1) or 30-day (Stage 2) upgrade delays, minus any withdrawal delay.
+
+**CROPS context (`cr: high`):** the rating holds only when the escape hatch contract has meaningful upgrade delays (Stage 1+ / 7 days minimum); instant upgrades let the operator remove the hatch, which invalidates `cr: high` entirely. In I2U, unilateral exit is non-optional: the CR rubric requires a concrete user escape path for anything above `low`. In I2I, institutional deployments may accept upgrade risk under bilateral governance (both parties on the multisig). DA withholding and proving liveness, documented as separate trade-offs below, are operational/liveness constraints, not censorship: they do not change the CR score, which measures whether a single party can exclude a user at the protocol level.
+
+**DA withholding:** validium DA committees can freeze all funds by refusing to share state. External DA Layers add a liveness dependency. On-chain calldata/blobs are immune but expensive. For privacy systems, data can sit on-chain yet be useless without decryption keys.
+
+**State freshness gap:** users can prove against the most recently anchored root. Any transactions after that root are lost. Anchoring intervals range from minutes (validity rollups) to hours.
+
+**Mass exit:** everyone hits L1 at once: gas prices spike, users with no L1 ETH cannot participate, and leveraged DeFi positions may create claims exceeding underlying bridge deposits.
+
+**Proving liveness:** for privacy systems, the user must retain their secrets and run a compatible prover. The prover code must be open-source, deterministically compilable, and match the L1 verifier's expected proof format. A version mismatch = funds frozen until governance acts. Browser WASM proving works but is 5-15x slower than native.
+
+**PQ exposure:** ZK systems relying on elliptic-curve pairings (Groth16/PLONK over BN254) are vulnerable to CRQC; see [Post-Quantum Threats](../domains/post-quantum.md). STARKs using hash-based commitments are not affected.
+
+## Example
+
+**Bank X operates a private payment L2 for its clients. The sequencer goes offline.**
+
+1. Client C holds 500 000 USDC in shielded notes on the L2; withdrawal requests to the sequencer time out
+2. Client C retrieves the latest state root anchored on L1 and builds a Merkle inclusion proof for their commitment
+3. Client C generates a ZK ownership proof and submits it to the L1 escape hatch contract (~300 000 gas)
+4. After the 7-day challenge period, Client C claims 500 000 USDC on L1 to a fresh address
+5. The L1 transaction reveals that _someone_ withdrew 500 000 USDC, but not which client or which L2 transactions funded the balance
+
+## See also
+
+- [Shielded ERC-20 Transfers](pattern-shielding.md): shielded pools whose CR depends on forced withdrawal
+- [Privacy L2s](pattern-privacy-l2s.md): L2 architectures where sequencer censorship is a risk
+- [Stateless Plasma Privacy](pattern-plasma-stateless-privacy.md): Plasma exit games as a specific instantiation
+- [Modular Privacy Stack](pattern-modular-privacy-stack.md): forced withdrawal as the Settlement-layer safety net
+- [ZK Proof Systems](pattern-zk-proof-systems.md): proof system taxonomy and PQ safety
+- [L2Beat Stages Framework](https://l2beat.com/stages): maturity classification for rollup escape hatches
+- [A Practical Rollup Escape Hatch Design (Zircuit, 2025)](https://arxiv.org/html/2503.23986v1): resolver contracts for DeFi positions
+- [L2Beat DA Risk Framework](https://forum.l2beat.com/t/the-data-availability-risk-framework/318): DA Layer risk evaluation methodology


### PR DESCRIPTION
Closes #125

## Summary
- New pattern: `pattern-forced-withdrawal.md` — three-pillar analysis (DA, L1 verifier, proving infra) with construction-level comparisons
- Updated `approach-white-label-deployment.md` and `approach-private-payments.md` with cross-references
- Updated CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Forced Withdrawal" pattern describing an L1 escape-hatch for bounded-time asset recovery when operators are unavailable; cross-linked from guidance documents.
  * Expanded approach guidance with liveness-fallback considerations and clarified exit/failure scenarios.
  * Standardized terminology by replacing “ZK proof” with “zero-knowledge proof” across docs.

* **Changelog**
  * Announced the new Forced Withdrawal pattern under Unreleased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->