### PR TITLE
feat(schema): pattern template v2 (schema + CI only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the IPTF Map are documented here.
 
 ## [Unreleased]
 
+- feat(schema): pattern template v2 — structured `crops_context`, `post_quantum`, `context_differentiation`, `related_patterns`, `open_source_implementations`, `sub_patterns`, and `type: meta` flag. `_template.md`, `scripts/schemas/pattern.json`, and `scripts/validate-patterns.js` updated. Validator stays permissive during migration; existing v1 patterns continue to pass with deprecation warnings. ([#150](https://github.com/ethereum/iptf-map/issues/150))
 - feat(pattern): [Onion Routing](patterns/pattern-onion-routing.md) -- Tor-based multi-hop relay for sender IP anonymity (PSE tor-js, Flashbots .onion) ([#146](https://github.com/ethereum/iptf-map/pull/146))
 - feat(pattern): [Mixnet Anonymity](patterns/pattern-mixnet-anonymity.md) -- batching, reordering, and cover traffic for strongest network anonymity (Nym, HOPR) ([#146](https://github.com/ethereum/iptf-map/pull/146))
 - refactor(pattern): split [Network-Level Anonymity](patterns/pattern-network-anonymity.md) into umbrella pattern linking onion routing, mixnet, and TEE sub-patterns ([#146](https://github.com/ethereum/iptf-map/pull/146))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IPTF Map are documented here.
 
 ## [Unreleased]
 
-- feat(schema): pattern template v2 — structured `crops_context`, `post_quantum`, `context_differentiation`, `related_patterns`, `open_source_implementations`, `sub_patterns`, and `type: meta` flag. `_template.md`, `scripts/schemas/pattern.json`, and `scripts/validate-patterns.js` updated. Validator stays permissive during migration; existing v1 patterns continue to pass with deprecation warnings. ([#150](https://github.com/ethereum/iptf-map/issues/150))
+- feat(schema): pattern template v2 -- structured `crops_context`, `post_quantum`, `context_differentiation`, `related_patterns`, `open_source_implementations`, `sub_patterns`, and `type: meta` flag in [_template.md](patterns/_template.md), [pattern.json](scripts/schemas/pattern.json), and [validate-patterns.js](scripts/validate-patterns.js). Validator stays permissive during migration; existing v1 patterns continue to pass with deprecation warnings. ([#152](https://github.com/ethereum/iptf-map/pull/152), [#150](https://github.com/ethereum/iptf-map/issues/150))
 - feat(pattern): [Onion Routing](patterns/pattern-onion-routing.md) -- Tor-based multi-hop relay for sender IP anonymity (PSE tor-js, Flashbots .onion) ([#146](https://github.com/ethereum/iptf-map/pull/146))
 - feat(pattern): [Mixnet Anonymity](patterns/pattern-mixnet-anonymity.md) -- batching, reordering, and cover traffic for strongest network anonymity (Nym, HOPR) ([#146](https://github.com/ethereum/iptf-map/pull/146))
 - refactor(pattern): split [Network-Level Anonymity](patterns/pattern-network-anonymity.md) into umbrella pattern linking onion routing, mixnet, and TEE sub-patterns ([#146](https://github.com/ethereum/iptf-map/pull/146))

--- a/patterns/_template.md
+++ b/patterns/_template.md
@@ -120,7 +120,7 @@ prefixed with the actor performing it in square brackets:
 
 1. [user] Deposit ERC-20 tokens into shielded pool contract
 2. [contract] Emit commitment on-chain
-3. [user] Execute shielded transfer (generate ZK proof client-side)
+3. [user] Execute shielded transfer (generate zero-knowledge proof client-side)
 4. [relayer] Submit the shielded transaction for gas abstraction
 5. [auditor] Verify via viewing key
 

--- a/patterns/_template.md
+++ b/patterns/_template.md
@@ -85,15 +85,17 @@ open_source_implementations:
     language: Noir
 
 # ─── META-PATTERN ONLY (type: meta) ─────────────────────────────────────────
-# If set, crops_profile may be 'n/a' and ## Protocol / ## Example become
-# optional. Each child is a slug resolved to patterns/pattern-<slug>.md.
-sub_patterns:
-  - name: "Onion routing (Tor-style)"
-    pattern: pattern-onion-routing
-    crops_summary: "High CR, high privacy, high latency"
-  - name: "Mixnet"
-    pattern: pattern-mixnet-anonymity
-    crops_summary: "Medium CR, full privacy, high latency"
+# DELETE THIS WHOLE BLOCK UNLESS type: meta above. The validator warns if
+# sub_patterns is populated on a standard pattern.
+# For meta patterns: crops_profile may be 'n/a' and ## Protocol / ## Example
+# become optional. Each child is a slug resolved to patterns/pattern-<slug>.md.
+# sub_patterns:
+#   - name: "Onion routing (Tor-style)"
+#     pattern: pattern-onion-routing
+#     crops_summary: "High CR, high privacy, high latency"
+#   - name: "Mixnet"
+#     pattern: pattern-mixnet-anonymity
+#     crops_summary: "Medium CR, full privacy, high latency"
 ---
 
 ## Intent

--- a/patterns/_template.md
+++ b/patterns/_template.md
@@ -1,41 +1,154 @@
 ---
+# ─── Identity ───────────────────────────────────────────────────────────────
 title: "Pattern: <short name>"
-status: draft|ready
-maturity: PoC|pilot|prod
-works-best-when: <bulleted, 1–3 lines>
-avoid-when: <bulleted, 1–3 lines>
-dependencies: [ERC-3643, EIP-7573, EAS, ...]
-context: i2i|i2u|both              # applicable relationship type
+status: draft | ready
+# One of: research (paper only), concept (spec, no code), testnet (PoC/pilot),
+#         production (mainnet with real usage).
+maturity: research | concept | testnet | production
+# Optional. `meta` patterns aggregate sub_patterns; see below.
+type: standard | meta
+layer: L1 | L2 | offchain | hybrid
+last_reviewed: YYYY-MM-DD
+
+# ─── When to use ────────────────────────────────────────────────────────────
+works-best-when:
+  - <1-3 bullets>
+avoid-when:
+  - <1-3 bullets>
+
+# ─── Relationship context ───────────────────────────────────────────────────
+# i2i = institution-to-institution, i2u = institution-to-user.
+# If `both`, context_differentiation below must be filled in.
+context: i2i | i2u | both
+
+# Required when context: both. Renders as a two-column callout in the Guide.
+context_differentiation:
+  i2i: "Symmetric trust; both parties have legal recourse"
+  i2u: "Asymmetric; CROPS must protect the user. Forced withdrawal is critical"
+
+# ─── CROPS ──────────────────────────────────────────────────────────────────
+# Badge values. Use the string 'n/a' for meta/evaluation patterns that do not
+# implement privacy directly.
 crops_profile:
-  cr: high|medium|low|none       # censorship resistance impact
-  os: yes|partial|no             # open source and free (source availability, forkability, exit paths)
-  privacy: full|partial|none     # privacy guarantees (who sees what — see CONTRIBUTING.md § Privacy)
-  security: high|medium|low       # strength of security guarantees (see CONTRIBUTING.md § Security)
+  cr: high | medium | low | none # Censorship Resistance
+  o: yes | partial | no # Openness (source availability, open standards, exit paths, forkability)
+  p: full | partial | none # Privacy (who sees what)
+  s: high | medium | low # Security (trust model, assumptions)
+
+# Narrative context for each CROPS dimension — where the badges drift up or
+# down in practice. Replaces the ad-hoc "CROPS context" bullet in Trade-offs.
+crops_context:
+  cr: "Reaches `high` on L1 permissionless pools. Drops to `low` on permissioned L2s with operator-controlled exit."
+  o: "..."
+  p: "..."
+  s: "..."
+
+# ─── Post-quantum exposure ──────────────────────────────────────────────────
+# Replaces the ad-hoc "Post-quantum" bullet in Trade-offs.
+post_quantum:
+  risk: high | medium | low
+  vector: "EC-based commitments (Groth16, PLONK/KZG) broken by CRQC; HNDL risk for encrypted notes"
+  mitigation: "STARK-based pools with hash commitments"
+
+# ─── Visibility matrix (optional) ───────────────────────────────────────────
+# Four-slot model for transaction-level patterns: who sees what. Skip for
+# infrastructure or primitive patterns where the model does not apply.
+visibility:
+  counterparty: [amounts, identities]
+  chain: [commitments, nullifiers]
+  regulator: [full_tx with viewing key]
+  public: []
+
+# ─── Standards & cross-references ───────────────────────────────────────────
+# Standards this pattern relies on. Flow-style array of standard identifiers
+# (ERC-XXX, EIP-XXX, ISO-XXXXX, etc.).
+standards: [ERC-20, ERC-5564, EIP-7573]
+
+# Cross-references to other patterns. Replaces the old `dependencies` field
+# and the pattern-to-pattern links that used to live in `## See also`.
+# Each entry is a slug matching patterns/pattern-<slug>.md — no paths, just
+# the slug. The validator resolves and checks the file exists.
+related_patterns:
+  requires: [pattern-shielding] # hard dependency — can't implement this without it
+  composes_with: [pattern-stealth-addresses] # works well together, optional
+  alternative_to: [pattern-tee-based-privacy] # competing approach to the same problem
+  see_also: [pattern-forced-withdrawal] # related for context
+
+# Known implementations (plural, neutral). Renamed from "reference
+# implementation" — that phrase has a specific meaning in standards contexts.
+open_source_implementations:
+  - url: https://github.com/Railgun-Privacy/contract
+    description: "Railgun shielded pool (L1, production)"
+    language: Solidity
+  - url: https://github.com/AztecProtocol/aztec-packages
+    description: "Aztec Network (privacy L2)"
+    language: Noir
+
+# ─── META-PATTERN ONLY (type: meta) ─────────────────────────────────────────
+# If set, crops_profile may be 'n/a' and ## Protocol / ## Example become
+# optional. Each child is a slug resolved to patterns/pattern-<slug>.md.
+sub_patterns:
+  - name: "Onion routing (Tor-style)"
+    pattern: pattern-onion-routing
+    crops_summary: "High CR, high privacy, high latency"
+  - name: "Mixnet"
+    pattern: pattern-mixnet-anonymity
+    crops_summary: "Medium CR, full privacy, high latency"
 ---
 
 ## Intent
+
 One short paragraph: the job this pattern does.
 
-## Ingredients
-- Standards/ER(C|IP)s
-- Infra (L1/L2, wallets, oracles)
-- Off-chain services (KMS, registry, RFQ, etc.)
+## Components
 
-## Protocol (concise)
-Numbered steps (5–8 max) from intent → settlement/audit.
+What makes up this pattern. Primitives, on-chain code, and off-chain services
+all belong here. Each item gets a short note on its role.
 
-## Guarantees
+- <Primitive or module> — <role it plays>
+- <Primitive or module> — <role it plays>
+
+If a component is also a standalone pattern in this map, link it via
+`related_patterns` rather than describing it in depth here.
+
+## Protocol
+
+Numbered steps (5-8 max) from intent to settlement/audit. Each step is
+prefixed with the actor performing it in square brackets:
+`[user]`, `[contract]`, `[relayer]`, `[prover]`, `[auditor]`, `[operator]`,
+`[regulator]`, etc.
+
+1. [user] Deposit ERC-20 tokens into shielded pool contract
+2. [contract] Emit commitment on-chain
+3. [user] Execute shielded transfer (generate ZK proof client-side)
+4. [relayer] Submit the shielded transaction for gas abstraction
+5. [auditor] Verify via viewing key
+
+Optional for `type: meta` patterns (use `sub_patterns` instead).
+
+## Guarantees & threat model
+
 - What it hides / proves
 - Atomicity / finality
 - Audit & ops signal
-- How guarantees differ in I2I vs I2U contexts (if applicable)
+- Threat model: who the adversary is, what assumptions break the guarantees,
+  and which failure modes are out of scope
 
 ## Trade-offs
+
+Generic performance, cost, DX notes and failure modes. CROPS context and
+post-quantum exposure now live in frontmatter (`crops_context`, `post_quantum`),
+not here.
+
 - Performance / cost / DX notes
 - Failure modes & mitigations
 
 ## Example
-“Bank A sells €5m zero-coupon to Bank B…” — 3–5 bullets showing flow.
+
+"Bank A sells €5m zero-coupon to Bank B…" — 3-5 bullets showing flow.
+Optional for `type: meta` patterns.
 
 ## See also
-Cross-link to related pattern cards.
+
+External references only: specs, blog posts, docs. Pattern-to-pattern links
+belong in `related_patterns`.

--- a/scripts/schemas/pattern.json
+++ b/scripts/schemas/pattern.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://iptf-map.ethereum.org/schemas/pattern.json",
-  "title": "IPTF Pattern Frontmatter",
-  "description": "Schema for pattern document frontmatter in IPTF Map",
+  "title": "IPTF Pattern Frontmatter (v2)",
+  "description": "Schema for pattern document frontmatter in IPTF Map. v2 adds structured context_differentiation, crops_context, post_quantum, related_patterns, open_source_implementations, and meta-pattern support. Backward-compatible: v1 fields (dependencies, old maturity values) still validate until the strict-mode flip.",
   "type": "object",
   "required": ["title", "status", "maturity", "crops_profile"],
   "properties": {
@@ -18,8 +18,22 @@
     },
     "maturity": {
       "type": "string",
-      "enum": ["experimental", "PoC", "pilot", "production", "prod"],
-      "description": "Technology maturity level"
+      "enum": [
+        "research",
+        "concept",
+        "testnet",
+        "production",
+        "experimental",
+        "PoC",
+        "pilot",
+        "prod"
+      ],
+      "description": "Technology maturity. v2 values: research | concept | testnet | production. v1 values (experimental, PoC, pilot, prod) are accepted during migration and will be removed in the strict-mode flip."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["standard", "meta"],
+      "description": "Pattern kind. 'meta' patterns aggregate sub_patterns and may omit crops_profile, Protocol, and Example. Defaults to 'standard' when absent."
     },
     "layer": {
       "type": "string",
@@ -29,14 +43,14 @@
     "privacy_goal": {
       "type": "string",
       "maxLength": 200,
-      "description": "One-line description of privacy goal"
+      "description": "DEPRECATED (v1). Not carried into v2 — the Intent paragraph covers this. Accepted during migration."
     },
     "assumptions": {
       "oneOf": [
         { "type": "string" },
         { "type": "array", "items": { "type": "string" } }
       ],
-      "description": "Key trust/infrastructure assumptions"
+      "description": "DEPRECATED (v1). Not carried into v2 — assumptions belong in body/Components. Accepted during migration."
     },
     "last_reviewed": {
       "type": "string",
@@ -60,7 +74,74 @@
     "dependencies": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "Required standards/infrastructure"
+      "description": "DEPRECATED (v1). Use `standards` and `related_patterns` in v2. Accepted during migration."
+    },
+    "standards": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Standards this pattern relies on (ERC-20, EIP-7573, etc.). Top-level replacement for v1 ingredients.standards."
+    },
+    "related_patterns": {
+      "type": "object",
+      "description": "Cross-references to other patterns. Slugs match pattern-<slug>.md. Replaces v1 `dependencies` for pattern refs.",
+      "properties": {
+        "requires": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^pattern-[a-z0-9-]+$" },
+          "description": "Hard dependencies — can't implement this without them"
+        },
+        "composes_with": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^pattern-[a-z0-9-]+$" },
+          "description": "Works well together, optional"
+        },
+        "alternative_to": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^pattern-[a-z0-9-]+$" },
+          "description": "Competing approach to the same problem"
+        },
+        "see_also": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^pattern-[a-z0-9-]+$" },
+          "description": "Related for context"
+        }
+      },
+      "additionalProperties": false
+    },
+    "open_source_implementations": {
+      "type": "array",
+      "description": "Known open-source implementations. Plural, neutral — multiple entries allowed.",
+      "items": {
+        "type": "object",
+        "required": ["url", "description"],
+        "properties": {
+          "url": { "type": "string", "format": "uri" },
+          "description": { "type": "string" },
+          "language": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "sub_patterns": {
+      "type": "array",
+      "description": "Children of a meta-pattern. Required when type: meta.",
+      "items": {
+        "type": "object",
+        "required": ["name", "pattern", "crops_summary"],
+        "properties": {
+          "name": { "type": "string" },
+          "pattern": {
+            "type": "string",
+            "pattern": "^pattern-[a-z0-9-]+$",
+            "description": "Slug resolved to patterns/pattern-<slug>.md"
+          },
+          "crops_summary": {
+            "type": "string",
+            "description": "One-line CROPS trade-off summary for this child"
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "rollout-plan": {
       "type": "string",
@@ -71,6 +152,23 @@
       "enum": ["i2i", "i2u", "both"],
       "description": "Applicable relationship type"
     },
+    "context_differentiation": {
+      "type": "object",
+      "description": "How the pattern applies differently in I2I vs I2U. Required when context: both (enforced by validator).",
+      "properties": {
+        "i2i": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How this plays out between institutions"
+        },
+        "i2u": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How this plays out for user-facing deployments; what extra protections are needed"
+        }
+      },
+      "additionalProperties": false
+    },
     "crops_profile": {
       "description": "CROPS dimension assessment. Use the string 'n/a' for meta/evaluation patterns that do not implement privacy directly.",
       "oneOf": [
@@ -80,32 +178,103 @@
         },
         {
           "type": "object",
-          "required": ["cr", "os", "privacy", "security"],
+          "required": ["cr"],
+          "anyOf": [
+            { "required": ["o"] },
+            { "required": ["os"] }
+          ],
+          "allOf": [
+            {
+              "anyOf": [
+                { "required": ["p"] },
+                { "required": ["privacy"] }
+              ]
+            },
+            {
+              "anyOf": [
+                { "required": ["s"] },
+                { "required": ["security"] }
+              ]
+            }
+          ],
           "properties": {
             "cr": {
               "type": "string",
               "enum": ["high", "medium", "low", "none"],
-              "description": "Censorship resistance impact"
+              "description": "Censorship resistance"
+            },
+            "o": {
+              "type": "string",
+              "enum": ["yes", "partial", "no"],
+              "description": "Openness: source availability, open standards, exit paths, forkability. The 'O' in CROPS — broader than just open source."
             },
             "os": {
               "type": "string",
               "enum": ["yes", "partial", "no"],
-              "description": "Open Source and Free: source availability, forkability, exit paths"
+              "description": "DEPRECATED (v1). Renamed to 'o' in v2 to match the CROPS acronym. 'O' stands for Openness, not Open Source. Accepted during migration."
+            },
+            "p": {
+              "type": "string",
+              "enum": ["full", "partial", "none"],
+              "description": "Privacy: full (private from everyone), partial (selective disclosure required), none (public or institution sees all)"
             },
             "privacy": {
               "type": "string",
               "enum": ["full", "partial", "none"],
-              "description": "Privacy guarantees: full (private from everyone), partial (selective disclosure required), none (public or institution sees all)"
+              "description": "DEPRECATED (v1). Renamed to 'p' in v2 to match the CROPS acronym. Accepted during migration."
+            },
+            "s": {
+              "type": "string",
+              "enum": ["high", "medium", "low"],
+              "description": "Security: strength of guarantees (cryptographic assumptions, decentralization, trust model)"
             },
             "security": {
               "type": "string",
               "enum": ["high", "medium", "low"],
-              "description": "Strength of security guarantees (cryptographic assumptions, decentralization, trust model)"
+              "description": "DEPRECATED (v1). Renamed to 's' in v2 to match the CROPS acronym. Accepted during migration."
             }
           },
           "additionalProperties": false
         }
       ]
+    },
+    "crops_context": {
+      "type": "object",
+      "description": "Narrative context for each CROPS dimension — where the badges drift up or down in practice. Replaces the ad-hoc 'CROPS context' bullet in Trade-offs. v2 uses single-letter keys (cr, o, p, s) to match crops_profile.",
+      "properties": {
+        "cr": { "type": "string" },
+        "o": { "type": "string" },
+        "os": { "type": "string", "description": "DEPRECATED: use 'o' in v2." },
+        "p": { "type": "string" },
+        "privacy": { "type": "string", "description": "DEPRECATED: use 'p' in v2." },
+        "s": { "type": "string" },
+        "security": { "type": "string", "description": "DEPRECATED: use 's' in v2." }
+      },
+      "additionalProperties": false
+    },
+    "visibility": {
+      "type": "object",
+      "description": "Optional four-slot visibility matrix for transaction-level patterns: who sees what. Skip for infrastructure or primitive patterns where the model does not apply.",
+      "properties": {
+        "counterparty": { "type": "array", "items": { "type": "string" } },
+        "chain": { "type": "array", "items": { "type": "string" } },
+        "regulator": { "type": "array", "items": { "type": "string" } },
+        "public": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "post_quantum": {
+      "type": "object",
+      "description": "Post-quantum exposure summary. Replaces the ad-hoc 'Post-quantum' bullet in Trade-offs.",
+      "properties": {
+        "risk": {
+          "type": "string",
+          "enum": ["high", "medium", "low"]
+        },
+        "vector": { "type": "string" },
+        "mitigation": { "type": "string" }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/scripts/validate-patterns.js
+++ b/scripts/validate-patterns.js
@@ -56,24 +56,34 @@ const REQUIRED_PATTERN_FRONTMATTER = [
   'crops_profile'
 ];
 
-// New frontmatter fields (warn only for now)
+// Recommended v2 frontmatter (warnings only). `privacy_goal` and
+// `assumptions` have been dropped from v2; they trigger deprecation warnings
+// in validateV2Fields rather than appearing as recommended.
 const RECOMMENDED_PATTERN_FRONTMATTER = [
   'layer',
-  'privacy_goal',
-  'assumptions',
   'last_reviewed'
 ];
 
-// Required sections in pattern documents
+// Required sections in pattern documents.
+// v2 notes:
+//   - `## Components` replaces `## Ingredients`
+//   - `## Guarantees & threat model` replaces `## Guarantees`
+//   - Either form is accepted during migration
+//   - `## Protocol` and `## Example` are skipped for `type: meta` patterns
+//     (handled inline in validatePattern).
 const REQUIRED_PATTERN_SECTIONS = [
   '## Intent',
-  '## Ingredients',
+  '## Ingredients|## Components',
   '## Protocol',
-  '## Guarantees',
+  '## Guarantees|## Guarantees & threat model',
   '## Trade-offs',
   '## Example',
   '## See also'
 ];
+
+// v2 maturity values. v1 values remain valid until the strict-mode flip.
+const V2_MATURITY_VALUES = ['research', 'concept', 'testnet', 'production'];
+const V1_MATURITY_VALUES = ['experimental', 'PoC', 'pilot', 'prod'];
 
 // Required sections for vendor documents
 const REQUIRED_VENDOR_SECTIONS = [
@@ -272,6 +282,60 @@ function validatePatternFileName(fileName) {
 }
 
 /**
+ * Validate v2-specific frontmatter fields. During migration these surface as
+ * warnings; the strict-mode flip promotes them to errors.
+ */
+function validateV2Fields(frontmatter, fileWarnings) {
+  // context: both requires context_differentiation with both slots filled.
+  if (frontmatter.context === 'both') {
+    const cd = frontmatter.context_differentiation;
+    if (!cd) {
+      fileWarnings.push(`v2: context is 'both' but context_differentiation is missing. Add both i2i and i2u strings.`);
+    } else {
+      if (!cd.i2i || String(cd.i2i).trim() === '') {
+        fileWarnings.push(`v2: context_differentiation.i2i is empty — required when context: both.`);
+      }
+      if (!cd.i2u || String(cd.i2u).trim() === '') {
+        fileWarnings.push(`v2: context_differentiation.i2u is empty — required when context: both.`);
+      }
+    }
+  }
+
+  // type: meta requires sub_patterns.
+  if (frontmatter.type === 'meta') {
+    if (!Array.isArray(frontmatter.sub_patterns) || frontmatter.sub_patterns.length === 0) {
+      fileWarnings.push(`v2: type is 'meta' but sub_patterns is empty.`);
+    }
+  }
+
+  // related_patterns slugs must resolve to an existing pattern file.
+  const rp = frontmatter.related_patterns;
+  if (rp && typeof rp === 'object') {
+    for (const slot of ['requires', 'composes_with', 'alternative_to', 'see_also']) {
+      const list = rp[slot];
+      if (!Array.isArray(list)) continue;
+      for (const slug of list) {
+        const target = path.join(PATTERNS_DIR, `${slug}.md`);
+        if (!fs.existsSync(target)) {
+          fileWarnings.push(`v2: related_patterns.${slot} references missing file ${slug}.md`);
+        }
+      }
+    }
+  }
+
+  // sub_patterns slugs must resolve to an existing pattern file.
+  if (Array.isArray(frontmatter.sub_patterns)) {
+    for (const sp of frontmatter.sub_patterns) {
+      if (!sp || !sp.pattern) continue;
+      const target = path.join(PATTERNS_DIR, `${sp.pattern}.md`);
+      if (!fs.existsSync(target)) {
+        fileWarnings.push(`v2: sub_patterns references missing file ${sp.pattern}.md`);
+      }
+    }
+  }
+}
+
+/**
  * Validate a single pattern file
  */
 function validatePattern(filePath) {
@@ -298,20 +362,29 @@ function validatePattern(filePath) {
     }
   }
 
-  // Validate crops_profile sub-fields (skip if explicitly opted out with "n/a")
+  // Validate crops_profile sub-fields (skip if explicitly opted out with "n/a").
+  // v2 renames CROPS fields to single-letter keys matching the acronym:
+  //   os → o  (Openness, not just open source)
+  //   privacy → p
+  //   security → s
+  // Old names are accepted during migration with a deprecation warning.
   if (frontmatter.crops_profile && frontmatter.crops_profile !== 'n/a') {
     const cp = frontmatter.crops_profile;
     const cropsFields = {
-      cr: ['high', 'medium', 'low', 'none'],
-      os: ['yes', 'partial', 'no'],
-      privacy: ['full', 'partial', 'none'],
-      security: ['high', 'medium', 'low']
+      cr: { allowed: ['high', 'medium', 'low', 'none'], legacy: null, label: 'Censorship resistance' },
+      o:  { allowed: ['yes', 'partial', 'no'], legacy: 'os', label: 'Openness' },
+      p:  { allowed: ['full', 'partial', 'none'], legacy: 'privacy', label: 'Privacy' },
+      s:  { allowed: ['high', 'medium', 'low'], legacy: 'security', label: 'Security' }
     };
-    for (const [field, allowed] of Object.entries(cropsFields)) {
-      if (!cp[field]) {
-        fileErrors.push(`crops_profile missing required field: ${field}`);
-      } else if (!allowed.includes(cp[field])) {
-        fileErrors.push(`crops_profile.${field} has invalid value '${cp[field]}'. Allowed: ${allowed.join(', ')}`);
+    for (const [field, spec] of Object.entries(cropsFields)) {
+      const value = cp[field] ?? (spec.legacy ? cp[spec.legacy] : undefined);
+      const usedKey = cp[field] !== undefined ? field : spec.legacy;
+      if (value === undefined) {
+        fileErrors.push(`crops_profile missing required field: ${field} (${spec.label})`);
+      } else if (!spec.allowed.includes(value)) {
+        fileErrors.push(`crops_profile.${usedKey} has invalid value '${value}'. Allowed: ${spec.allowed.join(', ')}`);
+      } else if (spec.legacy && cp[spec.legacy] !== undefined && cp[field] === undefined) {
+        fileWarnings.push(`v2: crops_profile.${spec.legacy} is deprecated — rename to '${field}' to match the CROPS acronym.`);
       }
     }
   }
@@ -355,22 +428,39 @@ function validatePattern(filePath) {
     fileErrors.push(`Invalid status value: ${frontmatter.status} (must be 'draft' or 'ready')`);
   }
 
-  if (frontmatter.maturity && !['experimental', 'PoC', 'pilot', 'production', 'prod'].includes(frontmatter.maturity)) {
-    fileWarnings.push(`Unexpected maturity value: ${frontmatter.maturity}`);
+  if (frontmatter.maturity) {
+    const m = frontmatter.maturity;
+    if (V1_MATURITY_VALUES.includes(m)) {
+      fileWarnings.push(`Deprecated v1 maturity value '${m}'. Migrate to v2: research | concept | testnet | production. (PoC|pilot → testnet; prod → production; experimental → manual review.)`);
+    } else if (!V2_MATURITY_VALUES.includes(m)) {
+      fileWarnings.push(`Unexpected maturity value: ${m}`);
+    }
   }
 
-  // Validate required sections
+  const isMeta = frontmatter.type === 'meta';
+
+  // Validate required sections. v2 accepts `## Components` in place of
+  // `## Ingredients`. Meta-patterns may omit Protocol / Example.
   for (const section of REQUIRED_PATTERN_SECTIONS) {
-    if (!content.includes(section)) {
+    if (isMeta && (section === '## Protocol' || section === '## Example')) {
+      continue;
+    }
+    const alternatives = section.split('|');
+    const hasAny = alternatives.some(s => content.includes(s));
+    if (!hasAny) {
+      const label = alternatives.join(' or ');
       // For existing patterns, only warn about missing sections
       const isNewPattern = !fs.existsSync(filePath.replace('feature/ci-infrastructure', 'master'));
       if (IS_CI && isNewPattern) {
-        fileErrors.push(`Missing required section: ${section}`);
+        fileErrors.push(`Missing required section: ${label}`);
       } else {
-        fileWarnings.push(`Missing required section: ${section}`);
+        fileWarnings.push(`Missing required section: ${label}`);
       }
     }
   }
+
+  // v2 checks (warnings during migration; promoted to errors in strict mode)
+  validateV2Fields(frontmatter, fileWarnings);
 
   // Validate internal links (warning only - enable blocking after fixing existing issues)
   const linkErrors = validateInternalLinks(filePath, content);

--- a/scripts/validate-patterns.js
+++ b/scripts/validate-patterns.js
@@ -301,11 +301,13 @@ function validateV2Fields(frontmatter, fileWarnings) {
     }
   }
 
-  // type: meta requires sub_patterns.
+  // type: meta requires sub_patterns; conversely, only meta patterns may set it.
   if (frontmatter.type === 'meta') {
     if (!Array.isArray(frontmatter.sub_patterns) || frontmatter.sub_patterns.length === 0) {
       fileWarnings.push(`v2: type is 'meta' but sub_patterns is empty.`);
     }
+  } else if (Array.isArray(frontmatter.sub_patterns) && frontmatter.sub_patterns.length > 0) {
+    fileWarnings.push(`v2: sub_patterns is populated but type is not 'meta'. Remove sub_patterns or set type: meta.`);
   }
 
   // related_patterns slugs must resolve to an existing pattern file.
@@ -455,6 +457,12 @@ function validatePattern(filePath) {
         fileErrors.push(`Missing required section: ${label}`);
       } else {
         fileWarnings.push(`Missing required section: ${label}`);
+      }
+    } else if (alternatives.length > 1) {
+      // Deprecation nudge: v1 heading present but v2 heading absent.
+      const [v1Heading, v2Heading] = alternatives;
+      if (content.includes(v1Heading) && !content.includes(v2Heading)) {
+        fileWarnings.push(`v2: section '${v1Heading}' is deprecated; rename to '${v2Heading}'.`);
       }
     }
   }


### PR DESCRIPTION
First of 3 PRs for #150 — schema + CI. Validator stays permissive; existing cards untouched (migration comes in the next PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced pattern frontmatter v2: richer metadata (type/meta, standards, related/sub-patterns, open‑source implementations, visibility matrix, post‑quantum fields, expanded CROPS profile/context) and reorganized body sections (Components, Protocol, threat‑model Guarantees, Trade‑offs, Example, See also).

* **Chores**
  * Migration preserves v1 compatibility: legacy patterns remain accepted while producing deprecation warnings and guidance; maturity taxonomy expanded with new values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->