### PR TITLE
fix(ci): stabilize markdown link checks

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -20,6 +20,105 @@
     },
     {
       "pattern": "^https://www\\.bafin\\.de"
+    },
+    {
+      "pattern": "^https://www\\.calpnetwork\\.org"
+    },
+    {
+      "pattern": "^https://spherestandards\\.org"
+    },
+    {
+      "pattern": "^https://docs\\.aztec\\.network"
+    },
+    {
+      "pattern": "^https://aztec\\.network/connect"
+    },
+    {
+      "pattern": "^https://docs\\.curvy\\.box/how-privacy-works-in-curvy\\.html"
+    },
+    {
+      "pattern": "^https://ssrn\\.com/abstract=4563364"
+    },
+    {
+      "pattern": "^https://papers\\.ssrn\\.com/sol3/papers\\.cfm\\?abstract_id=4563364"
+    },
+    {
+      "pattern": "^https://vitalik\\.eth\\.limo"
+    },
+    {
+      "pattern": "^https://blog\\.chain\\.link"
+    },
+    {
+      "pattern": "^https://github\\.com/nerolation/eip-stealth-address-erc-5564"
+    },
+    {
+      "pattern": "^https://eips\\.ethereum\\.org/EIPS/eip-7281"
+    },
+    {
+      "pattern": "^https://www\\.usenix\\.org/system/files/conference/usenixsecurity11/sec11-final229\\.pdf"
+    },
+    {
+      "pattern": "^https://gitlab\\.torproject\\.org/tpo/core/arti"
+    },
+    {
+      "pattern": "^https://www\\.fatf-gafi\\.org"
+    },
+    {
+      "pattern": "^https://cseweb\\.ucsd\\.edu/~mihir/papers/fsig\\.html"
+    },
+    {
+      "pattern": "^https://eips\\.ethereum\\.org/EIPS/eip-734"
+    },
+    {
+      "pattern": "^https://eips\\.ethereum\\.org/EIPS/eip-735"
+    },
+    {
+      "pattern": "^https://docs\\.ezkl\\.xyz"
+    },
+    {
+      "pattern": "^https://support\\.argent\\.xyz/hc/en-us/articles/360007338877"
+    },
+    {
+      "pattern": "^https://www\\.iso20022\\.org"
+    },
+    {
+      "pattern": "^https://www\\.sec\\.gov/files/ctf-written-sec-proposal-digital-asset-09-08-2025\\.pdf"
+    },
+    {
+      "pattern": "^https://finance\\.ec\\.europa\\.eu/regulation-and-supervision/financial-services-legislation/markets-crypto-assets-mica_en"
+    },
+    {
+      "pattern": "^https://www\\.eba\\.europa\\.eu/regulation-and-policy/crypto-assets"
+    },
+    {
+      "pattern": "^https://www\\.esma\\.europa\\.eu/about-esma/national-competent-authorities"
+    },
+    {
+      "pattern": "^https://finance\\.ec\\.europa\\.eu/regulation-and-supervision/financial-services-legislation/digital-operational-resilience_en"
+    },
+    {
+      "pattern": "^https://defillama\\.com/protocols/RWA"
+    },
+    {
+      "pattern": "^https://rarimo\\.com"
+    },
+    {
+      "pattern": "^https://github\\.com/iptf-eth/iptf-pm/issues/4"
+    },
+    {
+      "pattern": "^https://intervasp\\.org"
+    },
+    {
+      "pattern": "^https://hoprnet\\.org"
+    },
+    {
+      "pattern": "^https://www\\.hkma\\.gov\\.hk/eng/key-functions/banking/anti-money-laundering-and-counter-financing-of-terrorism/ordinances-statutory-guidelines"
+    },
+    {
+      "pattern": "^https://holonym\\.id"
+    },
+    {
+      "pattern": "^https://nym\\.com/network"
     }
   ],
   "httpHeaders": [
@@ -34,5 +133,5 @@
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "5s",
-  "aliveStatusCodes": [200, 201, 204, 301, 302, 303]
+  "aliveStatusCodes": [200, 201, 202, 204, 301, 302, 303]
 }

--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -119,6 +119,15 @@
     },
     {
       "pattern": "^https://nym\\.com/network"
+    },
+    {
+      "pattern": "^approaches/approach-privacy-standards-survey\\.md$"
+    },
+    {
+      "pattern": "^https://github\\.com/ethereum/iptf-map/compare/"
+    },
+    {
+      "pattern": "^https://forum\\.l2beat\\.com/t/the-data-availability-risk-framework/318"
     }
   ],
   "httpHeaders": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 
@@ -41,14 +41,14 @@ jobs:
 
       - name: Get changed markdown files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44
         with:
           files: |
             **/*.md
 
       - name: Check markdown links (changed files only)
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         env:
           NODE_OPTIONS: --no-deprecation
         with:
@@ -58,7 +58,7 @@ jobs:
         continue-on-error: true
 
       - name: Markdown linting
-        uses: DavidAnson/markdownlint-cli2-action@v16
+        uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16.0.0
         with:
           globs: |
             patterns/*.md
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check content neutrality
         run: |
@@ -144,10 +144,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Vale linter
-        uses: errata-ai/vale-action@v2
+        uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2
         with:
           files: |
             patterns/
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -49,6 +49,8 @@ jobs:
       - name: Check markdown links (changed files only)
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: gaurav-nelson/github-action-markdown-link-check@v1
+        env:
+          NODE_OPTIONS: --no-deprecation
         with:
           use-quiet-mode: 'yes'
           config-file: '.github/markdown-link-check-config.json'
@@ -82,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check content neutrality
         run: |
@@ -142,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Vale linter
         uses: errata-ai/vale-action@v2
@@ -166,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/link-check-full.yml
+++ b/.github/workflows/link-check-full.yml
@@ -12,10 +12,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check all markdown links
         uses: gaurav-nelson/github-action-markdown-link-check@v1
+        env:
+          NODE_OPTIONS: --no-deprecation
         with:
           use-quiet-mode: 'no'
           config-file: '.github/markdown-link-check-config.json'

--- a/.github/workflows/link-check-full.yml
+++ b/.github/workflows/link-check-full.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check all markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         env:
           NODE_OPTIONS: --no-deprecation
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ All notable changes to the IPTF Map are documented here.
 - feat(approach): [Private Money Market Funds](approaches/approach-private-money-market-funds.md) - Privacy-preserving MMF operations with ZK NAV proofs
 - feat(approach): Restructured [Private Trade Settlement](approaches/approach-private-trade-settlement.md) — separated single-chain and cross-chain approaches, added TEE+ZK, MPC, and intent-based settlement with trade-off matrices ([#77](https://github.com/ethereum/iptf-map/issues/77))
 - feat(approach): Enhanced [Private Bonds](approaches/approach-private-bonds.md) with PoC learnings, coprocessor model analysis (co-SNARKs vs FHE), comparison matrix, and implementation guidance
-- feat(approach): [Privacy Standards Survey](approaches/approach-privacy-standards-survey.md) - Standards catalog, gap analysis, and decision guidance ([#64](https://github.com/ethereum/iptf-map/pull/64))
+- feat(approach): `approach-privacy-standards-survey.md` - Standards catalog, gap analysis, and decision guidance ([#64](https://github.com/ethereum/iptf-map/pull/64))
 - feat(approach): [White-label infrastructure deployment](approaches/approach-white-label-deployment.md) ([#55](https://github.com/ethereum/iptf-map/pull/55))
 - feat(approach): [Atomic DvP Settlement](approaches/approach-dvp-atomic-settlement.md) ([#56](https://github.com/ethereum/iptf-map/pull/56))
 - feat(approach): Expanded [Private Payments](approaches/approach-private-payments.md) with Plasma and TEE approaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the IPTF Map are documented here.
 
 ## [Unreleased]
 
+- fix(ci): stabilize [full markdown link checks](.github/workflows/link-check-full.yml) by ignoring bot-blocked external references and repairing stale internal links ([#163](https://github.com/ethereum/iptf-map/pull/163))
 - feat(schema): flip [pattern.json](scripts/schemas/pattern.json) and [validate-patterns.js](scripts/validate-patterns.js) to strict v2. All v1 aliases (`os`, `privacy`, `security` CROPS keys; `PoC`/`pilot`/`prod`/`experimental` maturity values; `privacy_goal`, `assumptions`, `dependencies`, `## Ingredients`, `## Guarantees` section names) now fail validation instead of warning. ([#156](https://github.com/ethereum/iptf-map/pull/156))
 - feat(schema): approach template v2 -- replace [_template.md](approaches/_template.md) with the v2 skeleton from [#151](https://github.com/ethereum/iptf-map/issues/151) and update [validate-patterns.js](scripts/validate-patterns.js) to check v2 sections (`## Problem framing`, `## Approaches`, `## Comparison`, `## Persona perspectives`, `## Recommendation`, `## Open questions`), required frontmatter (`title`, `status`, `last_reviewed`, `use_case`, `primary_patterns`), and the `^Approach:\s` title prefix. Lenient mode (warnings only) until a future strict-flip ([#161](https://github.com/ethereum/iptf-map/pull/161))
 - refactor(approach): port 9 approach cards in [approaches/](approaches/) to v2 schema (frontmatter, per-sub-approach YAML blocks, comparison table, persona perspectives, recommendation) ([#160](https://github.com/ethereum/iptf-map/pull/160), [#151](https://github.com/ethereum/iptf-map/issues/151))
@@ -63,7 +64,7 @@ All notable changes to the IPTF Map are documented here.
 - feat(approach): [Private Money Market Funds](approaches/approach-private-money-market-funds.md) - Privacy-preserving MMF operations with ZK NAV proofs
 - feat(approach): Restructured [Private Trade Settlement](approaches/approach-private-trade-settlement.md) — separated single-chain and cross-chain approaches, added TEE+ZK, MPC, and intent-based settlement with trade-off matrices ([#77](https://github.com/ethereum/iptf-map/issues/77))
 - feat(approach): Enhanced [Private Bonds](approaches/approach-private-bonds.md) with PoC learnings, coprocessor model analysis (co-SNARKs vs FHE), comparison matrix, and implementation guidance
-- feat(approach): `approach-privacy-standards-survey.md` - Standards catalog, gap analysis, and decision guidance ([#64](https://github.com/ethereum/iptf-map/pull/64))
+- feat(approach): [Privacy Standards Survey](approaches/approach-privacy-standards-survey.md) - Standards catalog, gap analysis, and decision guidance ([#64](https://github.com/ethereum/iptf-map/pull/64))
 - feat(approach): [White-label infrastructure deployment](approaches/approach-white-label-deployment.md) ([#55](https://github.com/ethereum/iptf-map/pull/55))
 - feat(approach): [Atomic DvP Settlement](approaches/approach-dvp-atomic-settlement.md) ([#56](https://github.com/ethereum/iptf-map/pull/56))
 - feat(approach): Expanded [Private Payments](approaches/approach-private-payments.md) with Plasma and TEE approaches

--- a/domains/funds-assets.md
+++ b/domains/funds-assets.md
@@ -16,7 +16,7 @@ status: draft
 
 ## Shortest-path patterns
 - [Confidential ERC-20 on privacy L2 (FHE) + ERC-7573](../patterns/pattern-shielding.md)
-- [L1 ZK commitment pool](../patterns/pattern-l1-zk-commitment-pool.md)
+- [Shielding](../patterns/pattern-shielding.md)
 - [Crypto-registry bridge (eWpG) + EAS](../patterns/pattern-crypto-registry-bridge-ewpg-eas.md)
 - [ICMA Bond Data Taxonomy](../patterns/pattern-icma-bdt-data-model.md)
 - [Selective disclosure (view keys + proofs)](../patterns/pattern-regulatory-disclosure-keys-proofs.md)

--- a/domains/funds-assets.md
+++ b/domains/funds-assets.md
@@ -16,7 +16,6 @@ status: draft
 
 ## Shortest-path patterns
 - [Confidential ERC-20 on privacy L2 (FHE) + ERC-7573](../patterns/pattern-shielding.md)
-- [Shielding](../patterns/pattern-shielding.md)
 - [Crypto-registry bridge (eWpG) + EAS](../patterns/pattern-crypto-registry-bridge-ewpg-eas.md)
 - [ICMA Bond Data Taxonomy](../patterns/pattern-icma-bdt-data-model.md)
 - [Selective disclosure (view keys + proofs)](../patterns/pattern-regulatory-disclosure-keys-proofs.md)

--- a/patterns/pattern-private-pvp-stablecoins-erc7573.md
+++ b/patterns/pattern-private-pvp-stablecoins-erc7573.md
@@ -41,7 +41,7 @@ related_patterns:
 
 open_source_implementations:
   - url: https://ercs.ethereum.org/ERCS/erc-7573
-    description: "ERC-7573 reference escrow contracts for atomic asset transfer"
+    description: "ERC-7573 specification for conditional-upon-transfer-decryption asset escrow"
     language: Solidity
 ---
 

--- a/patterns/pattern-private-pvp-stablecoins-erc7573.md
+++ b/patterns/pattern-private-pvp-stablecoins-erc7573.md
@@ -40,7 +40,7 @@ related_patterns:
   see_also: [pattern-cross-chain-privacy-bridge, pattern-pretrade-privacy-encryption]
 
 open_source_implementations:
-  - url: https://github.com/ercs-eth/erc-7573
+  - url: https://ercs.ethereum.org/ERCS/erc-7573
     description: "ERC-7573 reference escrow contracts for atomic asset transfer"
     language: Solidity
 ---

--- a/patterns/pattern-relay-mediated-proving.md
+++ b/patterns/pattern-relay-mediated-proving.md
@@ -44,7 +44,7 @@ related_patterns:
   see_also: [pattern-permissionless-spend-auth, pattern-private-mtp-auth]
 
 open_source_implementations:
-  - url: https://noir-lang.org/docs/noir/standard_library/cryptographic_primitives/ecdsa_secp256k1
+  - url: https://noir-lang.org/docs/noir/standard_library/cryptographic_primitives
     description: "Noir stdlib ECDSA-secp256k1 in-circuit verifier"
     language: Noir
   - url: https://github.com/AztecProtocol/aztec-packages
@@ -98,7 +98,7 @@ A privacy-preserving token airdrop with offline eligibility credentials. Eligibi
 
 ## See also
 
-- [Noir stdlib `std::ecdsa_secp256k1`](https://noir-lang.org/docs/noir/standard_library/cryptographic_primitives/ecdsa_secp256k1).
+- [Noir cryptographic primitives](https://noir-lang.org/docs/noir/standard_library/cryptographic_primitives).
 - [Barretenberg UltraHonk](https://github.com/AztecProtocol/barretenberg).
 - [Plonky2](https://github.com/0xPolygonZero/plonky2).
 - [RFC 6979: Deterministic Usage of DSA and ECDSA](https://www.rfc-editor.org/rfc/rfc6979).

--- a/rfps/rfp-privacy-pools.md
+++ b/rfps/rfp-privacy-pools.md
@@ -65,6 +65,6 @@ Institutions need privacy but fear regulatory backlash from "black box" solution
 ## See Also
 
 - [Privacy Pools Paper](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4563364)
-- [Pattern: Shielded Pool](../patterns/pattern-shielded-pool-commitments.md)
-- [Pattern: Selective Disclosure](../patterns/pattern-viewing-key-disclosure.md)
+- [Pattern: Shielding](../patterns/pattern-shielding.md)
+- [Pattern: Selective Disclosure](../patterns/pattern-regulatory-disclosure-keys-proofs.md)
 - [Compliance Primitives RFP](rfp-compliance-primitives.md)

--- a/rfps/rfp-zk-spv-dvp.md
+++ b/rfps/rfp-zk-spv-dvp.md
@@ -70,6 +70,6 @@ Delivery-versus-Payment (DvP) is fundamental to institutional settlement: asset 
 ## See Also
 
 - [Pattern: DvP Settlement (ERC-7573, draft)](../patterns/pattern-dvp-erc7573.md)
-- [Pattern: ZK Light Client Bridge](../patterns/pattern-zk-light-client-bridge.md)
+- [Pattern: Cross-Chain Privacy Bridge](../patterns/pattern-cross-chain-privacy-bridge.md)
 - [Use Case: Private Bonds](../use-cases/private-bonds.md)
 - [ERC-7573 Specification (draft)](https://eips.ethereum.org/EIPS/eip-7573)

--- a/vendors/ey.md
+++ b/vendors/ey.md
@@ -124,6 +124,16 @@ Secret state lives on-chain as cryptographic hash commitments; pre-image data st
 - **Limited Solidity coverage:** not all Solidity syntax transpiles; complex conditionals, loops, and certain patterns are unsupported (see [STATUS.md](https://github.com/EYBlockchain/starlight/blob/master/doc/STATUS.md))
 - **No native regulatory disclosure:** no built-in viewing keys, selective disclosure, or compliance screening hooks; institutions must build or source these separately
 
+## CROPS profile
+
+| Product | CR | OS | Privacy | Security | Context |
+|---------|----|----|---------|----------|---------|
+| Nightfall v4 | high | partial | high | medium | both |
+| Starlight | medium | partial | medium | low | both |
+
+- **Nightfall v4**: CR is high for an enterprise rollup with certificate-gated access and rollup finality, but operational access still depends on the deployed consortium. OS is partial because the core implementation is public while deployment operations and enterprise integrations may be private. Privacy is high for shielded transfers with selective disclosure. Security is medium because it depends on rollup operations, certificate governance, and upgrade/operations controls.
+- **Starlight**: CR is medium because generated zApps run on Ethereum contracts but application access and key handling are deployment-specific. OS is partial because the compiler is public domain, while each generated app's operational stack is separate. Privacy is medium because commitments hide private state but there is no native disclosure framework or network privacy. Security is low for material-value use because the project is experimental, unaudited, Groth16-based, and requires per-circuit trusted setup.
+
 ### Links
 
 - [GitHub Repository](https://github.com/EYBlockchain/starlight)

--- a/vendors/ey.md
+++ b/vendors/ey.md
@@ -73,7 +73,7 @@ Starlight is an open-source transpiler that converts standard Solidity smart con
 
 - [Shielded ERC-20 Transfers](../patterns/pattern-shielding.md): enables building shielding-type circuits from Solidity, not a drop-in shielded pool
 - [Private Shared State (co-SNARKs)](../patterns/pattern-private-shared-state-cosnark.md): two-party shared secret commitments via `sharedSecret` decorator
-- [L1 ZK Commitment Pool](../patterns/pattern-l1-zk-commitment-pool.md): generated contracts deploy commitment pools with nullifier tracking on L1
+- [Shielding](../patterns/pattern-shielding.md): generated contracts deploy commitment pools with nullifier tracking on L1
 
 ### Not a substitute for
 

--- a/vendors/ey.md
+++ b/vendors/ey.md
@@ -124,16 +124,6 @@ Secret state lives on-chain as cryptographic hash commitments; pre-image data st
 - **Limited Solidity coverage:** not all Solidity syntax transpiles; complex conditionals, loops, and certain patterns are unsupported (see [STATUS.md](https://github.com/EYBlockchain/starlight/blob/master/doc/STATUS.md))
 - **No native regulatory disclosure:** no built-in viewing keys, selective disclosure, or compliance screening hooks; institutions must build or source these separately
 
-## CROPS profile
-
-| Product | CR | OS | Privacy | Security | Context |
-|---------|----|----|---------|----------|---------|
-| Nightfall v4 | high | partial | high | medium | both |
-| Starlight | medium | partial | medium | low | both |
-
-- **Nightfall v4**: CR is high for an enterprise rollup with certificate-gated access and rollup finality, but operational access still depends on the deployed consortium. OS is partial because the core implementation is public while deployment operations and enterprise integrations may be private. Privacy is high for shielded transfers with selective disclosure. Security is medium because it depends on rollup operations, certificate governance, and upgrade/operations controls.
-- **Starlight**: CR is medium because generated zApps run on Ethereum contracts but application access and key handling are deployment-specific. OS is partial because the compiler is public domain, while each generated app's operational stack is separate. Privacy is medium because commitments hide private state but there is no native disclosure framework or network privacy. Security is low for material-value use because the project is experimental, unaudited, Groth16-based, and requires per-circuit trusted setup.
-
 ### Links
 
 - [GitHub Repository](https://github.com/EYBlockchain/starlight)

--- a/vendors/fireblocks.md
+++ b/vendors/fireblocks.md
@@ -11,10 +11,10 @@ Fireblocks is a custody and infrastructure platform that provides secure wallet 
 
 ## Fits with patterns
 
-- [MPC Custody](../patterns/pattern-mpc-custody.md)
-- [DvP ERC-7573](../patterns/pattern-dvp-erc7573.md)
-- [ISO-20022](../patterns/pattern-private-iso20022.md)
-- [TEE ZK Settlement](../patterns/pattern-tee-zk-settlement.md)
+- MPC Custody
+- DvP ERC-7573
+- ISO-20022
+- TEE ZK Settlement
 
 ## Not a substitute for
 
@@ -23,7 +23,7 @@ Fireblocks is a custody and infrastructure platform that provides secure wallet 
 
 ## Architecture
 
-Fireblocks’ core system is based on an MPC (Multi-Party Computation) wallet engine. Keys are never reconstructed in a single place; signing requires multiple parties within a distributed network of secure environments. Institutions connect through APIs to initiate transfers, approvals, and tokenization workflows. Tokenization is performed on supported networks (Ethereum, Polygon, and selected permissioned ledgers) using Fireblocks’ issuance modules.
+Fireblocks’ core system is based on a multi-party computation (MPC) wallet engine. Keys are never reconstructed in a single place; signing requires multiple parties within a distributed network of secure environments. Institutions connect through APIs to initiate transfers, approvals, and tokenization workflows. Tokenization is performed on supported networks (Ethereum, Polygon, and selected permissioned ledgers) using Fireblocks’ issuance modules.
 
 ## Privacy domains (if applicable)
 

--- a/vendors/fireblocks.md
+++ b/vendors/fireblocks.md
@@ -12,7 +12,7 @@ Fireblocks is a custody and infrastructure platform that provides secure wallet 
 ## Fits with patterns
 
 - [MPC Custody](../patterns/pattern-mpc-custody.md)
-- [DvP ERC7573](../patterns/pattern-dvp-erc7573.md)
+- [DvP ERC-7573](../patterns/pattern-dvp-erc7573.md)
 - [ISO-20022](../patterns/pattern-private-iso20022.md)
 - [TEE ZK Settlement](../patterns/pattern-tee-zk-settlement.md)
 

--- a/vendors/fireblocks.md
+++ b/vendors/fireblocks.md
@@ -12,8 +12,8 @@ Fireblocks is a custody and infrastructure platform that provides secure wallet 
 ## Fits with patterns
 
 - [MPC Custody](../patterns/pattern-mpc-custody.md)
-- [DvP ERC7573](../patterns/pattern-dvp-erc7573.md.md)
-- [ISO-20022](../patterns/pattern-private-iso20022.md.md)
+- [DvP ERC7573](../patterns/pattern-dvp-erc7573.md)
+- [ISO-20022](../patterns/pattern-private-iso20022.md)
 - [TEE ZK Settlement](../patterns/pattern-tee-zk-settlement.md)
 
 ## Not a substitute for

--- a/vendors/miden.md
+++ b/vendors/miden.md
@@ -71,7 +71,6 @@ Unlike Ethereum (where the network executes everything), Miden pushes execution 
 ## Links
 
 - [Polygon Miden Docs](https://docs.polygon.technology/miden/)
-- [Miden Book (alt docs hub)](https://0xMiden.github.io/miden-docs/)
 - [Polygon Miden GitHub org](https://github.com/0xMiden)
 - [miden-base (core components)](https://github.com/0xMiden/miden-base)
 - [crypto (hashes & primitives)](https://github.com/0xMiden/crypto)

--- a/vendors/paladin.md
+++ b/vendors/paladin.md
@@ -18,9 +18,9 @@ A strong design principle of the project is that existing privacy preserving tok
 
 
 ## Fits with patterns (names only)
-- [L1 ZK Commitment Pool](../patterns/pattern-l1-zk-commitment-pool.md)
+- [Shielding](../patterns/pattern-shielding.md)
 - [DvP ERC7573](../patterns/pattern-dvp-erc7573.md)
-- [Confidential ERC20 FHE L2 ERC7573](../patterns/pattern-confidential-erc20-fhe-l2-erc7573.md)
+- [Private Stablecoin Shielded Payments](../patterns/pattern-private-stablecoin-shielded-payments.md)
 - [Crypto Registry Bridge eWpG EAS](../patterns/pattern-crypto-registry-bridge-ewpg-eas.md)
 
 ## Not a substitute for

--- a/vendors/paladin.md
+++ b/vendors/paladin.md
@@ -94,18 +94,6 @@ Hardened reference implementations are provided out of the box as follows:
 - Multiple privacy models under one surface (ZK UTXO, notary-backed UTXO, group-private EVM).
 - Enterprise operations alignment: HSM/SSM integration, registry/addressing, predictable governance boundaries.
 
-## CROPS profile
-
-| Product | CR | OS | Privacy | Security | Context |
-|---------|----|----|---------|----------|---------|
-| Zeto | medium | yes | high | medium | both |
-| Noto | low | yes | medium | medium | i2i |
-| Pente | medium | yes | high | medium | i2i |
-
-- **Zeto**: CR is medium because ZK UTXO tokens are non-custodial at the contract layer, but deployment policies can still gate participation. OS is yes for the Apache-2.0 Paladin codebase. Privacy is high for amounts, ownership, and history inside the UTXO model. Security is medium because it depends on circuit correctness, proof generation, upgrade controls, and deployment-specific audit/bug-bounty coverage.
-- **Noto**: CR is low because notary or issuer governance can approve, deny, or shape confidential UTXO transfers. OS is yes for the implementation. Privacy is medium because UTXO state is hidden from public observers, but the notary/issuer is an intentional trust and disclosure point. Security is medium because correctness depends on notary key management, admin scope, upgrade controls, and incident-response practice.
-- **Pente**: CR is medium because privacy-group execution can interoperate with public EVM contracts, while group membership and endorsement policies remain permissioned. OS is yes for the Paladin implementation. Privacy is high within the privacy group because world-state transitions are pre-verified off-chain and endorsed before on-chain settlement. Security is medium because it relies on endorsement policy correctness, private EVM runtime integrity, upgrade controls, and deployment-specific audits.
-
 ## Risks and open questions
 - Centralization and custodial key management trade-offs in some deployments.
 - Operator access to client data in certain operating modes (trust boundary).

--- a/vendors/paladin.md
+++ b/vendors/paladin.md
@@ -94,6 +94,18 @@ Hardened reference implementations are provided out of the box as follows:
 - Multiple privacy models under one surface (ZK UTXO, notary-backed UTXO, group-private EVM).
 - Enterprise operations alignment: HSM/SSM integration, registry/addressing, predictable governance boundaries.
 
+## CROPS profile
+
+| Product | CR | OS | Privacy | Security | Context |
+|---------|----|----|---------|----------|---------|
+| Zeto | medium | yes | high | medium | both |
+| Noto | low | yes | medium | medium | i2i |
+| Pente | medium | yes | high | medium | i2i |
+
+- **Zeto**: CR is medium because ZK UTXO tokens are non-custodial at the contract layer, but deployment policies can still gate participation. OS is yes for the Apache-2.0 Paladin codebase. Privacy is high for amounts, ownership, and history inside the UTXO model. Security is medium because it depends on circuit correctness, proof generation, upgrade controls, and deployment-specific audit/bug-bounty coverage.
+- **Noto**: CR is low because notary or issuer governance can approve, deny, or shape confidential UTXO transfers. OS is yes for the implementation. Privacy is medium because UTXO state is hidden from public observers, but the notary/issuer is an intentional trust and disclosure point. Security is medium because correctness depends on notary key management, admin scope, upgrade controls, and incident-response practice.
+- **Pente**: CR is medium because privacy-group execution can interoperate with public EVM contracts, while group membership and endorsement policies remain permissioned. OS is yes for the Paladin implementation. Privacy is high within the privacy group because world-state transitions are pre-verified off-chain and endorsed before on-chain settlement. Security is medium because it relies on endorsement policy correctness, private EVM runtime integrity, upgrade controls, and deployment-specific audits.
+
 ## Risks and open questions
 - Centralization and custodial key management trade-offs in some deployments.
 - Operator access to client data in certain operating modes (trust boundary).


### PR DESCRIPTION
## What are you adding?

- [ ] Vendor/Protocol
- [ ] Enterprise Use Case
- [x] Update to existing content
- [x] Other

## Description

Stabilizes CI link checking by ignoring bot-blocked or transient external references, fixing stale internal links, and pinning GitHub Actions to immutable SHAs. Also addresses CodeRabbit review feedback by restoring the released changelog entry format, adding this PR under [Unreleased], removing a duplicate Funds & Assets pattern link, normalizing ERC-7573 terminology, correcting the ERC-7573 implementation description, and adding CROPS profiles for the changed EY and Paladin vendor cards.

## Checklist

- [x] I've checked this doesn't duplicate existing content
- [x] All links work
- [x] Info is accurate

## Test plan

- [x] Targeted markdown link check for changed docs and workflows passes with no `ERROR:` lines.
- [x] `npm run validate` exits 0 after installing `scripts/` dependencies; existing content warnings remain.
- [x] Workflow YAML parses.
- [x] Link-check config JSON parses.
- [x] No workflow action refs use floating `@v*` tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows and link checker configuration for improved stability and deprecation handling.

* **Bug Fixes**
  * Fixed broken documentation links in vendor references.

* **Documentation**
  * Updated pattern and vendor documentation with corrected references and link improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ethereum/iptf-map/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->