### PR TITLE
domains: add "## Approach lens" section to separate solution framing from use-case framing

### DIFF
--- a/domains/data-oracles.md
+++ b/domains/data-oracles.md
@@ -6,6 +6,8 @@ status: draft
 ## TLDR
 - Price feeds, ISO/SWIFT messages, disclosure anchors, proofs of reserves, compliance attestations, and oracle trust models.
 - Resilience uses: trusted facts during crisis, local attestations, property and identity evidence, public verification without exposing the underlying source data.
+
+## Approach lens
 - Bind settlement to signed facts; anchor commitments/roots for audit.
 
 ## Primary use cases

--- a/domains/funds-assets.md
+++ b/domains/funds-assets.md
@@ -8,6 +8,8 @@ status: draft
 - Public-sector and NGO claims: entitlements, vouchers, permits, beneficiary rights, post-crisis records that need verifiable audit without exposing the holder.
 - Hide amounts/positions; preserve DvP finality; bridge legal records via attestations.
 - Derivatives: daily deltas/margins hidden; regulator replayable audit.
+
+## Approach lens
 - Pick cheapest viable privacy that meets audit needs; measure costs under 4844.
 
 ## Primary use cases

--- a/domains/payments.md
+++ b/domains/payments.md
@@ -7,6 +7,8 @@ status: draft
 - Institutional cash movement: payouts, PvP, DvP cash legs, treasury flows, workflow/memo privacy with stakeholder-only visibility and ISO/SWIFT linkage when needed.
 - Public-sector and NGO disbursement: benefits, aid, grants, vouchers, emergency cash, donor-to-recipient flows with private eligibility and recipient unlinkability.
 - Resilience payments: offline or low-connectivity transfer, hostile-authority settings, off-ramp unlinkability, recipient devices without client-side proving capability.
+
+## Approach lens
 - Measure latency, finality, and costs on the target L2 or app-chain; avoid HTLC brittleness.
 
 ## Primary use cases

--- a/domains/post-quantum.md
+++ b/domains/post-quantum.md
@@ -7,6 +7,8 @@ status: draft
 
 - A Cryptographically Relevant Quantum Computer (CRQC) breaks ECDSA, BLS, ECDH, Groth16, PLONK/KZG — Ethereum consensus, execution, and application privacy layers all affected.
 - Harvest Now, Decrypt Later (HNDL) means confidentiality-critical applications face urgency now, even though CRQC is years away.
+
+## Approach lens
 - Hash-based and lattice-based primitives provide migration paths; STARKs are already PQ-safe.
 
 ## PQ Threat Landscape

--- a/domains/trading.md
+++ b/domains/trading.md
@@ -6,6 +6,8 @@ status: draft
 ## TLDR
 - Execution privacy: RFQ intent/size/price, pre-trade leakage control across private trading, derivatives, and OTC settlement.
 - Public-sector and NGO procurement and settlement where counterparties, prices, or allocations are sensitive.
+
+## Approach lens
 - Cross-domain atomicity (DvP/PvP) without HTLCs; optional zk-SPV for strong atomicity.
 
 ## Primary use cases


### PR DESCRIPTION
## What

Splits the single approach-oriented bullet out of each domain's `## TLDR` into a new `## Approach lens` section. Applied to the five domains that have such a bullet:

- `payments` — "Measure latency, finality, and costs on the target L2 or app-chain; avoid HTLC brittleness."
- `data-oracles` — "Bind settlement to signed facts; anchor commitments/roots for audit."
- `funds-assets` — "Pick cheapest viable privacy that meets audit needs; measure costs under 4844."
- `trading` — "Cross-domain atomicity (DvP/PvP) without HTLCs; optional zk-SPV for strong atomicity."
- `post-quantum` — "Hash-based and lattice-based primitives provide migration paths; STARKs are already PQ-safe."

**No prose is added or rewritten.** Each change relocates one existing bullet under a new heading. `custody`, `governance`, and `identity-compliance` have no clearly approach-oriented TLDR bullet and are intentionally left unchanged.

## Why

The IPTF guide website renders a domain's `## TLDR` as the per-domain section primer on **both** the use-cases listing and the approaches listing:

- https://iptf-prototype.netlify.app/use-cases/
- https://iptf-prototype.netlify.app/approaches/

Because both pages read the same `## TLDR`, every domain shows identical primer text on the two listings (e.g. the Payments section reads the same on both). The two listings serve different reading needs — one frames the institutional *question*, the other the *solution architecture* — so identical text reads as a bug.

A distinct `## Approach lens` lets a consumer render use-case framing on the use-cases listing and solution framing on the approaches listing, both sourced from this repo rather than hand-written downstream.

## Status: draft / RFC

Opening as a draft to check whether the maintainers:

1. Agree with the `## Approach lens` heading name and placement (immediately after `## TLDR`).
2. Want it extended to `custody` / `governance` / `identity-compliance`, which would need a new approach-oriented line authored by someone with domain ownership (deliberately not fabricated here).
3. Prefer a different split (e.g. keeping the bullet in TLDR and adding a separate prose sentence).

A companion change on the website side would read `## Approach lens` for the approaches listing once this lands. No website behavior changes until then; this PR alone only moves a bullet under a new heading.

## Validation

- No schema covers `domains/*.md` (schemas exist only for patterns, use-cases, jurisdictions, vendors), so heading changes don't affect schema CI.
- No links added or removed; markdown link-check is unaffected.