### PR TITLE
fix: update Zama vendor file to current protocol architecture and mainnet status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the EthSystems Map are documented here.
 
 ## [Unreleased]
 
+- fix(vendor): [Zama](vendors/zama.md) — mainnet maturity, symbolic-execution architecture, TFHE-rs, ERC-7984; sync fhEVM status and docs link in [Private Shared State (FHE)](patterns/pattern-private-shared-state-fhe.md) ([#180](https://github.com/ethsystems/map/pull/180))
+
 ## [0.4.0] - 2026-07-02
 
 23 commits, 166 files changed since [v0.3.0](https://github.com/ethsystems/map/releases/tag/v0.3.0) (Apr 2026). Major additions: resilience use cases (civic participation, disbursement rails, identity continuity), I2U protection patterns, pattern/approach schema v2 (strict flip) with CROPS and post-quantum analysis, domain reframing beyond FIs, and a Q2 2026 content QA audit.

--- a/patterns/pattern-private-shared-state-fhe.md
+++ b/patterns/pattern-private-shared-state-fhe.md
@@ -46,7 +46,7 @@ related_patterns:
 
 open_source_implementations:
   - url: https://github.com/zama-ai/fhevm
-    description: "Zama fhEVM, Fully Homomorphic Encryption runtime for EVM contracts (testnet)"
+    description: "Zama fhEVM, Fully Homomorphic Encryption runtime for EVM contracts (mainnet)"
     language: "Solidity, Rust"
   - url: https://github.com/zama-ai/tfhe-rs
     description: "TFHE-rs, pure-Rust implementation of TFHE primitives used by coprocessors"
@@ -109,4 +109,4 @@ Threat model:
 
 - [Zama](../vendors/zama.md)
 - [Fhenix](../vendors/fhenix.md)
-- [Zama fhEVM documentation](https://docs.zama.ai/fhevm)
+- [Zama Protocol documentation (FHE on blockchain)](https://docs.zama.org/protocol/protocol/overview)

--- a/vendors/zama.md
+++ b/vendors/zama.md
@@ -52,13 +52,11 @@ The protocol combines the FHEVM Solidity library; host contracts that enforce ac
 ## Strengths
 
 - Host contracts deploy onto existing chains, EVM or non-EVM, so users do not move to a dedicated network
-- Composable between confidential contracts and with non-confidential ones
+- Composable between confidential contracts and with non-confidential ones, and contracts are written in plain Solidity rather than a new language
 - Every FHE computation and input verification carries a commitment and a signature, so anyone can recompute the result and check it independently
-- No single party ever holds the decryption key: it is secret-shared across the threshold network, and each decryption is authorized by the Access Control List and logged through the Gateway
-- Confidential contracts are written in plain Solidity, without a new language or cryptography expertise
+- No single party ever holds the decryption key: it is secret-shared across the threshold network, and each decryption is authorized by the Access Control List
 - Compliance rules are defined by each application in its own contracts rather than by the protocol
-- Audited by Trail of Bits and Zenith
-- The FHE and multi-party computation layers are post-quantum
+- Audited by Trail of Bits and Zenith, and the FHE and multi-party computation layers are post-quantum
 
 ## Risks and open questions
 

--- a/vendors/zama.md
+++ b/vendors/zama.md
@@ -27,7 +27,7 @@ Zama develops open-source Fully Homomorphic Encryption (FHE) tooling and operate
 
 Contracts import the FHEVM Solidity library and use encrypted types (`euint8` to `euint256`, `ebool`, `eaddress`). Each encrypted value is referenced on-chain by a 32-byte handle. Zama's documentation places the ciphertext itself "off-chain, with the coprocessor" and the handle on-chain as the identifier pointing to it. FHE operations run symbolically on the host chain, generating new handles and emitting events, while a network of coprocessors performs the computation using TFHE-rs.
 
-The protocol has five components: the FHEVM Solidity library; host contracts that enforce access control and emit events; coprocessors that verify inputs, execute FHE operations and store ciphertexts; the Gateway, a dedicated Arbitrum rollup that orchestrates input validation, decryption and bridging; and a threshold multi-party computation Key Management Service.
+The protocol combines the FHEVM Solidity library; host contracts that enforce access control and emit events; coprocessors that verify inputs, execute FHE operations and store ciphertexts; the Gateway, a dedicated Arbitrum rollup that orchestrates input validation, decryption and bridging; and a threshold multi-party computation Key Management Service. Relayer and oracle services connect users and contracts to the Gateway and are not part of the trusted base.
 
 ## Privacy domains
 
@@ -51,20 +51,21 @@ The protocol has five components: the FHEVM Solidity library; host contracts tha
 
 ## Strengths
 
-- Runs on existing chains, so users do not bridge to a separate network
+- Host contracts deploy onto existing chains, EVM or non-EVM, so users do not move to a dedicated network
 - Composable between confidential contracts and with non-confidential ones
+- Every FHE computation and input verification carries a commitment and a signature, so anyone can recompute the result and check it independently
+- No single party ever holds the decryption key: it is secret-shared across the threshold network, and each decryption is authorized by the Access Control List and logged through the Gateway
+- Confidential contracts are written in plain Solidity, without a new language or cryptography expertise
 - Compliance rules are defined by each application in its own contracts rather than by the protocol
-- The FHE scheme is post-quantum
+- Audited by Trail of Bits and Zenith
+- The FHE and multi-party computation layers are post-quantum
 
 ## Risks and open questions
 
-- Decryption depends on the threshold Key Management Service: 13 multi-party computation nodes, with a documented threshold example of 9 of 13, giving a correct output with up to one third malicious nodes
-- Those nodes run inside AWS Nitro Enclaves, so verifiability rests partly on hardware assumptions. Zama states the goal is to add zero-knowledge proofs to the multi-party computation protocol to remove that dependency
-- Coprocessor correctness rests on a majority-honest assumption, backed by staking and slashing
-- The zero-knowledge proof used for input verification is not yet post-quantum, unlike the FHE and multi-party computation layers
+- The trust model is layered: decryption runs through a threshold Key Management Service of 13 multi-party computation nodes, with a documented threshold example of 9 of 13 and tolerance up to one third malicious; those nodes run inside AWS Nitro Enclaves, so verifiability rests partly on hardware assumptions; and coprocessor correctness rests on a majority-honest assumption backed by staking and slashing. Zama states the goal is to add zero-knowledge proofs to the multi-party computation protocol to remove the hardware dependency
 - Operators can pause the protocol and blacklist addresses, and the Access Control List carries an account deny list
-- Interoperability between Fully Homomorphic Encryption networks is still emerging
-- Throughput and cost stay above plaintext execution, and protocol support beyond Ethereum mainnet is roadmap rather than shipped
+- Open source under a dual license: free for non-commercial use, with a commercial license required for use outside the Zama Protocol
+- Cost and latency stay above plaintext execution, and protocol support beyond Ethereum mainnet is roadmap rather than shipped
 
 ## Links
 

--- a/vendors/zama.md
+++ b/vendors/zama.md
@@ -1,62 +1,79 @@
 ---
 title: "Vendor: Zama"
 status: ready
-maturity: testnet
+maturity: mainnet
 ---
 
-# Zama – FHE SDK & Confidential Smart Contracts (Fully Homomorphic Encryption for EVM)
+# Zama – Confidential Blockchain Protocol (Fully Homomorphic Encryption on existing chains)
 
 ## What it is
 
-Zama develops **open-source FHE (Fully Homomorphic Encryption)** tools that enable confidential smart contracts and encrypted data processing directly on EVM-compatible networks.
+Zama develops open-source Fully Homomorphic Encryption (FHE) tooling and operates the Zama Confidential Blockchain Protocol, which lets smart contracts compute on encrypted data on existing public chains. Zama describes it as "not a new L1 or L2, but rather a cross-chain confidentiality layer sitting on top of existing chains", so applications stay on their host chain instead of migrating to a dedicated network. Ethereum mainnet is live; further EVM chains and Solana are on the published roadmap.
 
 ## Fits with patterns
 
-- [Private Stablecoin Shielded Payments](../patterns/pattern-private-stablecoin-shielded-payments.md) - FHE enables encrypted balances/amounts for confidential transfers
-- [Private Intent-Based Vaults](../patterns/pattern-private-vaults.md) - FHE-enabled chains allow private strategy execution while keeping assets auditable
-- [Shielded ERC-20 Transfers](../patterns/pattern-shielding.md) - Native FHE implementation for confidential token transfers
-- [Private L2s](../patterns/pattern-privacy-l2s.md) - Zama's fhEVM provides FHE-based rollup capabilities
-- [Shielding](../patterns/pattern-shielding.md) - FHE can complement ZK approaches for confidential balance management
+- [Private Shared State (FHE)](../patterns/pattern-private-shared-state-fhe.md) - encrypted state shared between parties, computed off-chain by coprocessors
+- [Private Stablecoin Shielded Payments](../patterns/pattern-private-stablecoin-shielded-payments.md) - encrypted balances and transfer amounts
+- [Private Intent-Based Vaults](../patterns/pattern-private-vaults.md) - strategy parameters stay encrypted during execution
+- [Shielding](../patterns/pattern-shielding.md) - partial fit: ERC-7984 hides amounts and balances, but sender and receiver stay public
 
 ## Not a substitute for
 
-- ZK-based L2 privacy (e.g., Aztec, Scroll)
-- MPC or TEEs for off-chain privacy computation
+- Graph privacy: sender and recipient addresses remain public, so unlinkability needs composition with stealth addresses
+- Privacy rollups that move execution and state off the host chain entirely
+- Multi-party computation or Trusted Execution Environments as general-purpose off-chain compute
 
 ## Architecture
 
-Smart contracts are compiled with Zama’s FHE libraries (e.g., `concrete`, `fhEVM`) allowing arithmetic on encrypted values. Execution happens deterministically, with ciphertexts persisted on-chain.
+Contracts import the FHEVM Solidity library and use encrypted types (`euint8` to `euint256`, `ebool`, `eaddress`). Each encrypted value is referenced on-chain by a 32-byte handle. Zama's documentation places the ciphertext itself "off-chain, with the coprocessor" and the handle on-chain as the identifier pointing to it. FHE operations run symbolically on the host chain, generating new handles and emitting events, while a network of coprocessors performs the computation using TFHE-rs.
+
+The protocol has five components: the FHEVM Solidity library; host contracts that enforce access control and emit events; coprocessors that verify inputs, execute FHE operations and store ciphertexts; the Gateway, a dedicated Arbitrum rollup that orchestrates input validation, decryption and bridging; and a threshold multi-party computation Key Management Service.
 
 ## Privacy domains
 
-- FHE encryption at the contract and variable level.
-- Supports hybrid models (FHE + ZK for verification).
+- Fully Homomorphic Encryption at the contract and variable level: amounts and balances stay encrypted end to end
+- Programmable access per ciphertext through an Access Control List (`allow`, `allowThis`, `allowTransient`, `makePubliclyDecryptable`), including delegation of user decryption
+- Hybrid by design: zero-knowledge proofs validate encrypted inputs, multi-party computation performs threshold decryption
 
 ## Enterprise demand and use cases
 
-- Financial institutions seeking **on-chain confidentiality** with deterministic settlement.
-- Private vaults, confidential lending, or yield strategies.
+- Confidential payments and stablecoin transfers where amounts and balances stay hidden from other participants
+- Tokenization and real-world assets where holdings and allocation sizes are confidential but settlement stays on a public chain
+- Sealed-bid auctions, confidential distributions and governance, where inputs stay private until a defined reveal
 
 ## Technical details
 
-- EVM-compatible FHE runtime (`fhEVM`)
-- SDKs for Solidity and TypeScript
-- Ongoing collaborations with Fhenix and Aleph Zero
+- FHEVM Solidity library (`@fhevm/solidity`), with a relayer SDK and a Hardhat plugin
+- Confidential tokens follow ERC-7984, implemented in OpenZeppelin's confidential-contracts library
+- Encrypted inputs carry a zero-knowledge proof of knowledge, validated through `FHE.fromExternal`
+- Conditional logic uses `FHE.select` instead of plaintext branching, so the taken branch is not revealed
+- Protocol fees apply to input verification, decryption and bridging. They are priced in USD and can be paid by the end user, the application or a relayer
 
 ## Strengths
 
-- Native EVM integration
-- Strong cryptographic research pedigree
-- Open-source and actively maintained
+- Runs on existing chains, so users do not bridge to a separate network
+- Composable between confidential contracts and with non-confidential ones
+- Compliance rules are defined by each application in its own contracts rather than by the protocol
+- The FHE scheme is post-quantum
 
 ## Risks and open questions
 
-- High compute cost and latency
-- Limited developer tooling maturity
-- Interoperability between FHE networks still emerging
+- Decryption depends on the threshold Key Management Service: 13 multi-party computation nodes, with a documented threshold example of 9 of 13, giving a correct output with up to one third malicious nodes
+- Those nodes run inside AWS Nitro Enclaves, so verifiability rests partly on hardware assumptions. Zama states the goal is to add zero-knowledge proofs to the multi-party computation protocol to remove that dependency
+- Coprocessor correctness rests on a majority-honest assumption, backed by staking and slashing
+- The zero-knowledge proof used for input verification is not yet post-quantum, unlike the FHE and multi-party computation layers
+- Operators can pause the protocol and blacklist addresses, and the Access Control List carries an account deny list
+- Interoperability between Fully Homomorphic Encryption networks is still emerging
+- Throughput and cost stay above plaintext execution, and protocol support beyond Ethereum mainnet is roadmap rather than shipped
 
 ## Links
 
-- [https://www.zama.ai](https://www.zama.ai)
-- [https://github.com/zama-ai/fhevm](https://github.com/zama-ai/fhevm)
-- [Confidential ERC-20](https://www.zama.ai/post/confidential-erc-20-tokens-using-homomorphic-encryption)
+- [Zama Protocol documentation](https://docs.zama.org/protocol)
+- [Litepaper](https://docs.zama.org/protocol/zama-protocol-litepaper)
+- [Handles: what lives on-chain and off-chain](https://docs.zama.org/protocol/solidity-guides/smart-contract/handles)
+- [Coprocessor](https://docs.zama.org/protocol/protocol/overview/coprocessor)
+- [Gateway](https://docs.zama.org/protocol/protocol/overview/gateway)
+- [Key Management Service](https://docs.zama.org/protocol/protocol/overview/kms)
+- [Access Control List](https://docs.zama.org/protocol/solidity-guides/smart-contract/acl)
+- [zama-ai/fhevm](https://github.com/zama-ai/fhevm)
+- [TFHE-rs](https://github.com/zama-ai/tfhe-rs)


### PR DESCRIPTION
## What are you adding?

- [ ] Vendor/Protocol
- [ ] Enterprise Use Case
- [x] Update to existing content
- [ ] Other

## Description

The Zama entry described an older architecture and was still marked testnet. Rewrote it against Zama's current documentation.

1. **Maturity.** `testnet` → `mainnet`. Ethereum mainnet is live per the [litepaper roadmap](https://docs.zama.org/protocol/zama-protocol-litepaper).

2. **Architecture.** The file said ciphertexts are persisted on-chain. In the Zama Protocol the on-chain value is a 32-byte handle and the ciphertext sits off-chain with the coprocessor ([handles](https://docs.zama.org/protocol/solidity-guides/smart-contract/handles), [coprocessor](https://docs.zama.org/protocol/protocol/overview/coprocessor)). Rewritten around symbolic execution and the five protocol components. Also replaced `concrete` with TFHE-rs and `@fhevm/solidity`: Concrete ML is a separate product line.

3. **Pattern fits.** Dropped Private L2s, since the litepaper states the protocol is "not a new L1 or L2, but rather a cross-chain confidentiality layer sitting on top of existing chains". Added Private Shared State (FHE). Marked Shielding as a partial fit, because ERC-7984 hides amounts and balances but not sender and receiver.

4. **Risks.** Added the trust assumptions the CROPS security rubric asks for: [KMS threshold](https://docs.zama.org/protocol/protocol/overview/kms) (13 nodes, a documented 9 of 13 example, tolerance up to one third malicious, AWS Nitro Enclaves), coprocessor majority-honest assumption, ZKPoK not yet post-quantum while FHE and MPC are, and operator pause plus the account deny list.

5. **Strengths.** Rewritten from generic claims to specific, sourced ones: public verifiability of coprocessor results, distributed key custody, the plain-Solidity developer surface, and audit status.

6. **Additions.** ERC-7984 with the OpenZeppelin confidential-contracts reference, and the ACL functions. Terminology fix "FHE encryption" → "Fully Homomorphic Encryption", one of the `check-terms` findings tracked in #67.

7. **`patterns/pattern-private-shared-state-fhe.md`.** The fhEVM implementation note still said testnet, and the `docs.zama.ai/fhevm` link redirects to a generic docs homepage. Both corrected. The pattern's own `maturity` frontmatter is untouched, since that is a judgment about the pattern family rather than a fact about Zama.

Notes:

- I am not affiliated with Zama. Every claim above links to Zama's own documentation.
- Dropped "Limited developer tooling maturity" from Risks, since the current stack ships a Hardhat plugin, Foundry support and an SDK. Happy to restore it if you read that differently.
- No CROPS profile added. No existing vendor file carries one, and scoring a third party seemed like your call rather than mine. Happy to draft one against the rubric if useful.
- Ran `npm run validate` and `npm run check-terms` locally. Output is unchanged except `vendors/zama.md` dropping off the check-terms list.

## Checklist

- [x] I've checked this doesn't duplicate existing content
- [x] All links work
- [x] Info is accurate

