### PR TITLE
feat(jurisdiction): add EU / EUDR deforestation regulation card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the EthSystems Map are documented here.
 
 ## [Unreleased]
 
+- feat(jurisdiction): [EU / EUDR (Deforestation Regulation)](jurisdictions/eu-EUDR.md) -- Article 9 plot-level geolocation and the DDS reference-number model, ahead of the 30 December 2026 application date
+
 ## [0.4.0] - 2026-07-02
 
 23 commits, 166 files changed since [v0.3.0](https://github.com/ethsystems/map/releases/tag/v0.3.0) (Apr 2026). Major additions: resilience use cases (civic participation, disbursement rails, identity continuity), I2U protection patterns, pattern/approach schema v2 (strict flip) with CROPS and post-quantum analysis, domain reframing beyond FIs, and a Q2 2026 content QA audit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the EthSystems Map are documented here.
 
 ## [Unreleased]
 
-- feat(jurisdiction): [EU / EUDR (Deforestation Regulation)](jurisdictions/eu-EUDR.md) -- Article 9 plot-level geolocation and the DDS reference-number model, ahead of the 30 December 2026 application date
+- feat(jurisdiction): [EU / EUDR (Deforestation Regulation)](jurisdictions/eu-EUDR.md) -- Article 9 plot-level geolocation and the DDS reference-number model, ahead of the 30 December 2026 application date ([#181](https://github.com/ethsystems/map/pull/181))
 
 ## [0.4.0] - 2026-07-02
 

--- a/jurisdictions/eu-EUDR.md
+++ b/jurisdictions/eu-EUDR.md
@@ -1,0 +1,33 @@
+---
+title: "Jurisdiction: EU / EUDR (Deforestation Regulation)"
+status: ready
+region: EU
+scope:
+  entities: [operators, traders, downstream operators, importers]
+  activities: [due diligence, geolocation reporting, supply chain traceability]
+key-regulations:
+  - EUDR (Reg. (EU) 2023/1115)
+  - Amending Reg. (EU) 2025/2650
+  - Commission simplification review (COM(2026) 191 final)
+last_reviewed: 2026-08-02
+---
+
+> Developer orientation. Not legal advice.
+
+## At a Glance
+
+The EUDR bars products linked to deforestation after 31 December 2020 from the EU market. It applies from 30 December 2026 to large and medium operators and to micro and small operators in the timber sector, with remaining micro and small operators following on 30 June 2027. Regulation (EU) 2025/2650 set those dates, and the Commission's simplification review of 4 May 2026 confirmed them without further delay. The obligation that matters technically is Article 9: operators collect latitude and longitude to six decimal digits for every plot of land, expressed as a polygon where the plot exceeds four hectares, and lodge that data in a due diligence statement (DDS) in the EU Information System. The regime is settled and already confidentiality aware, because business-to-business transmission downstream carries a DDS reference number rather than the coordinates themselves, but compliance still rests on plot-level geolocation held centrally.
+
+## What to Watch
+
+- A draft Delegated Act amending Annex I on product scope remains open for feedback.
+- Whether hiding geolocation within the Information System satisfies operators that treat plot boundaries as commercially sensitive sourcing data.
+- Smallholder plot polygons can constitute personal data as well as commercial data, which brings GDPR into scope alongside the EUDR.
+- Country benchmarking assigns risk categories that determine how much due diligence each supply chain requires.
+
+## See also
+
+- [Regulation (EU) 2023/1115 (consolidated) – EUR-Lex](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02023R1115-20251226)
+- [Deforestation-free products – European Commission](https://environment.ec.europa.eu/topics/forests/deforestation/regulation-deforestation-free-products_en)
+- [Jurisdiction: EU Data Protection & PETs](./eu-data-protection.md)
+- [Private Supply Chain use case](../use-cases/private-supply-chain.md)


### PR DESCRIPTION
## What are you adding?

- [ ] Vendor/Protocol
- [ ] Enterprise Use Case
- [ ] Update to existing content
- [x] Jurisdiction

## Description

Adds `jurisdictions/eu-EUDR.md`. There is currently no EUDR card in the map, and the geolocation mandate is a privacy problem sitting inside a supply chain regime.

### Why now

The Commission published its simplification package on 4 May 2026 (COM(2026) 191 final), confirming the application date with no further delay. Large and medium operators, plus micro and small operators in the timber sector, are in scope from **30 December 2026**. Remaining micro and small operators follow on **30 June 2027**. Those dates were set by Regulation (EU) 2025/2650.

### The part that concerns this map

Article 9 requires latitude and longitude to six decimal digits for every plot of land, expressed as a polygon where the plot exceeds four hectares, lodged in a due diligence statement in the EU Information System.

Two details make this more interesting than a straight disclosure mandate:

- Downstream business-to-business transmission carries a **DDS reference number rather than the coordinates**, and the Information System can hide geolocations even from parties referencing the DDS. Confidentiality is already a design goal of the regime.
- Smallholder plot polygons are commercially sensitive **and** personal data at the same time, which puts EUDR against the EU data protection card.

### Scope

Follows `jurisdictions/_template.md`: frontmatter in the established six-key order, the developer-orientation blockquote, `## At a Glance`, `## What to Watch`, `## See also`. Descriptive throughout, with no compliance steps or operational advice. Roughly 180 words, in line with the other seven cards.

### Checks

- `CI_MODE=strict npm run validate` passes with zero warnings against this file
- `check-terms` clean
- Vale clean (0 errors, 0 warnings, 0 suggestions)

CHANGELOG entry added under `[Unreleased]`, referencing this PR.

### Note for reviewers

`patterns/pattern-private-geospatial-attestation.md` is deliberately not linked here, since it arrives in a separate PR (#184). That link gets added there.

## Checklist

- [x] I've checked this doesn't duplicate existing content
- [x] All links work
- [x] Info is accurate
